### PR TITLE
Improve live site documentation

### DIFF
--- a/docs/analyzer/broker-reference.md
+++ b/docs/analyzer/broker-reference.md
@@ -1,0 +1,50 @@
+# Broker Reference
+
+All MeshCore.ca observer paths publish to the same redundant broker pair.
+
+| Broker | Host | Port | Transport | TLS | Token audience |
+|--------|------|------|-----------|-----|----------------|
+| Primary | `mqtt1.meshcore.ca` | `443` | WebSockets | Enabled + verified | `mqtt1.meshcore.ca` |
+| Backup | `mqtt2.meshcore.ca` | `443` | WebSockets | Enabled + verified | `mqtt2.meshcore.ca` |
+
+Use JWT token authentication where the setup tool exposes it. Do not set a static MQTT password unless a path-specific guide tells you to.
+
+## Topic Pattern
+
+Most observer paths publish packet telemetry under this pattern:
+
+```text
+meshcore/{IATA}/{PUBLIC_KEY}/packets
+```
+
+Status topics generally use:
+
+```text
+meshcore/{IATA}/{PUBLIC_KEY}/status
+```
+
+`{IATA}` must be a real 3-letter airport code nearest to the observer. `{PUBLIC_KEY}` is supplied by the MeshCore node or integration.
+
+## Payload Mode
+
+MeshCore.ca packet visibility needs packet payload publishing, not only status publishing.
+
+| Path | Required packet setting |
+|------|-------------------------|
+| MQTT firmware | `set mqtt.packets on`, `set bridge.enabled on`, `set mqtt.rx on`, `set mqtt.tx advert` |
+| MCtoMQTT | Broker config created by the MeshCore.ca helper |
+| Companion capture | `PACKETCAPTURE_MQTT*_TOPIC_PACKETS` configured |
+| PyMC | `format: letsmesh` |
+| Home Assistant | **Payload Mode** = `packet`, or older **Packets (Lets Mesh)** enabled |
+| RemoteTerm | Community MQTT packet topic template enabled |
+
+## Common Broker Mistakes
+
+| Symptom | Likely cause |
+|---------|--------------|
+| Primary connects, backup fails | Backup token audience still set to `mqtt1.meshcore.ca` |
+| Observer appears under the wrong city | IATA field is wrong or inconsistent between broker entries |
+| Broker connects but no packets appear | Status is publishing, but packet payload mode is not enabled |
+| Nothing appears | Radio is off the local mesh, IATA code is invalid, or outbound WSS is blocked |
+
+For path-specific commands, use [Troubleshooting](troubleshooting.md).

--- a/docs/analyzer/builds/meshcore-ha.md
+++ b/docs/analyzer/builds/meshcore-ha.md
@@ -67,7 +67,7 @@ The Home Assistant integration must use the same IATA code as the observer that 
 Current MeshCore-HA versions use a free-text **Broker IATA Code** field, so you can type a real code such as `YTR` even if it is missing from a quick list. If your Home Assistant screen only offers a picker and does not let you enter the code manually, update the MeshCore integration before using a neighboring airport code as a workaround.
 
 !!! tip
-    You can find common Canadian IATA codes on the [Analyzer Overview](../intro.md) page. If your nearest real airport code is missing from that quick list, you can still use it.
+    You can find common Canadian IATA codes on the [IATA Region Codes](../iata-codes.md) page. If your nearest real airport code is missing from that quick list, you can still use it.
 
 ## Common HA Symptoms
 

--- a/docs/analyzer/builds/mqtt-firmware.md
+++ b/docs/analyzer/builds/mqtt-firmware.md
@@ -41,7 +41,7 @@ Pick your board, role, and flash type to get the right firmware image.
 Most users should choose **First Flash (Merged)**, download the file, then flash it with the [MeshCore Flasher](https://flasher.meshcore.io/). No `esptool` offsets are needed when using the picker download.
 
 <div id="fw-picker" style="margin: 1.5em 0;">
-  <div id="fw-loading" style="padding: 1em; opacity: 0.6;">Loading firmware manifest...</div>
+  <div id="fw-loading" style="padding: 1em; opacity: 0.75;">Loading firmware manifest... If this does not change, use the static download table below or download from GitHub Releases.</div>
   <div id="fw-selects" style="display: none; flex-wrap: wrap; gap: 1em; margin-bottom: 1em;">
     <div style="flex: 1; min-width: 160px;">
       <label for="fw-board" style="display: block; font-weight: 600; margin-bottom: 0.3em; font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.7;">Board</label>
@@ -198,6 +198,25 @@ Most users should choose **First Flash (Merged)**, download the file, then flash
 })();
 </script>
 
+### Static Download Index
+
+If the firmware picker does not load, use this static table. **First Flash (Merged)** is the right choice for a new board, erased board, or recovery flash. Use **Update** only on a device already running MeshCore.
+
+| Board | Role | First Flash (Merged) | Update |
+|-------|------|----------------------|--------|
+| Heltec V3 | Repeater | [Download](firmware/meshcore-ca-heltec-v3-repeater-20260521-merged.bin) | [Download](firmware/meshcore-ca-heltec-v3-repeater-20260521-update.bin) |
+| Heltec V3 | Room Server | [Download](firmware/meshcore-ca-heltec-v3-room-server-20260521-merged.bin) | [Download](firmware/meshcore-ca-heltec-v3-room-server-20260521-update.bin) |
+| Heltec V4 OLED | Repeater | [Download](firmware/meshcore-ca-heltec-v4-oled-repeater-20260521-merged.bin) | [Download](firmware/meshcore-ca-heltec-v4-oled-repeater-20260521-update.bin) |
+| Heltec V4 OLED | Room Server | [Download](firmware/meshcore-ca-heltec-v4-oled-room-server-20260521-merged.bin) | [Download](firmware/meshcore-ca-heltec-v4-oled-room-server-20260521-update.bin) |
+| LILYGO T3S3 SX1262 | Repeater | [Download](firmware/meshcore-ca-lilygo-t3s3-sx1262-repeater-20260521-merged.bin) | [Download](firmware/meshcore-ca-lilygo-t3s3-sx1262-repeater-20260521-update.bin) |
+| LILYGO T3S3 SX1262 | Room Server | [Download](firmware/meshcore-ca-lilygo-t3s3-sx1262-room-server-20260521-merged.bin) | [Download](firmware/meshcore-ca-lilygo-t3s3-sx1262-room-server-20260521-update.bin) |
+| LILYGO T-Beam S3 Supreme SX1262 | Repeater | [Download](firmware/meshcore-ca-lilygo-t-beam-s3-supreme-sx1262-repeater-20260521-merged.bin) | [Download](firmware/meshcore-ca-lilygo-t-beam-s3-supreme-sx1262-repeater-20260521-update.bin) |
+| LILYGO T-Beam S3 Supreme SX1262 | Room Server | [Download](firmware/meshcore-ca-lilygo-t-beam-s3-supreme-sx1262-room-server-20260521-merged.bin) | [Download](firmware/meshcore-ca-lilygo-t-beam-s3-supreme-sx1262-room-server-20260521-update.bin) |
+| LILYGO T-Beam SX1262 | Repeater | [Download](firmware/meshcore-ca-lilygo-tbeam-sx1262-repeater-20260521-merged.bin) | [Download](firmware/meshcore-ca-lilygo-tbeam-sx1262-repeater-20260521-update.bin) |
+| LILYGO T-Beam SX1262 | Room Server | [Download](firmware/meshcore-ca-lilygo-tbeam-sx1262-room-server-20260521-merged.bin) | [Download](firmware/meshcore-ca-lilygo-tbeam-sx1262-room-server-20260521-update.bin) |
+| Seeed XIAO ESP32S3 + Wio-SX1262 | Repeater | [Download](firmware/meshcore-ca-seeed-xiao-s3-wio-sx1262-repeater-20260521-merged.bin) | [Download](firmware/meshcore-ca-seeed-xiao-s3-wio-sx1262-repeater-20260521-update.bin) |
+| Seeed XIAO ESP32S3 + Wio-SX1262 | Room Server | [Download](firmware/meshcore-ca-seeed-xiao-s3-wio-sx1262-room-server-20260521-merged.bin) | [Download](firmware/meshcore-ca-seeed-xiao-s3-wio-sx1262-room-server-20260521-update.bin) |
+
 ## Prerequisites
 
 | Requirement | Details |
@@ -222,7 +241,7 @@ Most users should choose **First Flash (Merged)**, download the file, then flash
 | First Flash (Merged) | New board, erased board, recovery from a bad flash | `0x00000` |
 | Update | Device already running MeshCore with a valid bootloader and partition table | `0x10000` |
 
-Technical users can still flash with their preferred ESP tool. Laymen should use the MeshCore Flasher and the **First Flash (Merged)** picker option.
+Technical users can still flash with their preferred ESP tool. Most users should use the MeshCore Flasher and the **First Flash (Merged)** picker option.
 
 ## CLI Setup
 

--- a/docs/analyzer/builds/mqtt-firmware.md
+++ b/docs/analyzer/builds/mqtt-firmware.md
@@ -245,7 +245,31 @@ Technical users can still flash with their preferred ESP tool. Most users should
 
 ## CLI Setup
 
-After flashing, connect to the device's admin CLI (serial or web) to set your WiFi, IATA code, and node name. Replace `YOW` with the real 3-letter airport code nearest to you and fill in your network credentials:
+After flashing, connect to the device's admin CLI (serial or web) to set your WiFi, IATA code, and node name.
+
+### Guided Heltec V3 / V4 Setup
+
+For Heltec V3 and Heltec V4 OLED boards running the MeshCore.ca direct MQTT firmware, the guided setup script prompts for your board, role, IATA code, WiFi network, WiFi password, node name, broker restore choice, and repeat/observe-only mode. It also applies the MeshCore Canada radio values, 3-byte path hash mode, and required MQTT packet publishing settings:
+
+```bash
+bash <(curl -fsSL https://meshcore.ca/analyzer/scripts/setup-mqtt-firmware.sh)
+```
+
+The script can send the commands over USB serial on Linux or macOS, or print a copy/paste command block for the web/admin CLI. If you already know the serial port, pass it directly:
+
+```bash
+bash <(curl -fsSL https://meshcore.ca/analyzer/scripts/setup-mqtt-firmware.sh) --port /dev/ttyUSB0
+```
+
+To generate commands without touching a serial port:
+
+```bash
+bash <(curl -fsSL https://meshcore.ca/analyzer/scripts/setup-mqtt-firmware.sh) --print-only
+```
+
+### Manual CLI Setup
+
+If you prefer to configure the device manually, replace `YOW` with the real 3-letter airport code nearest to you and fill in your network credentials:
 
 ```text
 set name YOW-Repeater-01

--- a/docs/analyzer/builds/mqtt-firmware.md
+++ b/docs/analyzer/builds/mqtt-firmware.md
@@ -261,10 +261,28 @@ The script can send the commands over USB serial on Linux or macOS, or print a c
 bash <(curl -fsSL https://meshcore.ca/analyzer/scripts/setup-mqtt-firmware.sh) --port /dev/ttyUSB0
 ```
 
+On Windows, use the PowerShell helper:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -Command "iex (iwr -UseBasicParsing https://meshcore.ca/analyzer/scripts/setup-mqtt-firmware.ps1).Content"
+```
+
+If you already know the COM port, pass it directly:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -Command "& ([scriptblock]::Create((iwr -UseBasicParsing https://meshcore.ca/analyzer/scripts/setup-mqtt-firmware.ps1).Content)) -Port COM3"
+```
+
 To generate commands without touching a serial port:
 
 ```bash
 bash <(curl -fsSL https://meshcore.ca/analyzer/scripts/setup-mqtt-firmware.sh) --print-only
+```
+
+Windows print-only mode:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -Command "& ([scriptblock]::Create((iwr -UseBasicParsing https://meshcore.ca/analyzer/scripts/setup-mqtt-firmware.ps1).Content)) -PrintOnly"
 ```
 
 ### Manual CLI Setup

--- a/docs/analyzer/iata-codes.md
+++ b/docs/analyzer/iata-codes.md
@@ -1,0 +1,147 @@
+# IATA Region Codes
+
+Each observer identifies its region with a real 3-letter IATA airport code. Use the airport code nearest to the observer's real location.
+
+The firmware and helper scripts are not limited to the list below. If your nearest real IATA code is missing here, you can still use it and the public broker will accept it as long as it is a valid airport code. The live site will add observed regions to the picker automatically, but codes missing from the friendly-name list may appear as the bare code until we add a label.
+
+Do not use placeholders or made-up region names such as `XXX` or `HOME`. Do not use `CAN` as shorthand for Canada; it is a real airport code for Guangzhou and will tag your observer to the wrong region.
+
+Host-side helper scripts show this same quick list interactively when you omit `--iata`.
+
+??? note "Ontario"
+
+    | Code | Region |
+    |------|--------|
+    | YYZ | Toronto (Pearson) |
+    | YTZ | Toronto (Billy Bishop) |
+    | YOW | Ottawa |
+    | YHM | Hamilton |
+    | YKF | Kitchener / Waterloo |
+    | YXU | London |
+    | YOO | Oshawa |
+    | YKZ | Buttonville / Markham |
+    | YAM | Sault Ste. Marie |
+    | YQT | Thunder Bay |
+    | YSB | Sudbury |
+    | YTS | Timmins |
+    | YQG | Windsor |
+    | YYB | North Bay |
+    | YGK | Kingston |
+    | YPQ | Peterborough |
+    | YTR | Trenton / Quinte West |
+    | YHD | Dryden |
+    | YPL | Pickle Lake |
+    | YND | Gatineau (Ottawa area) |
+
+??? note "Quebec"
+
+    | Code | Region |
+    |------|--------|
+    | YUL | Montreal (Trudeau) |
+    | YMX | Montreal (Mirabel) |
+    | YQB | Quebec City |
+    | YBG | Bagotville / Saguenay |
+    | YVO | Val-d'Or |
+    | YHU | Montreal (St-Hubert) |
+    | YRJ | Roberval |
+    | YGL | La Grande Riviere |
+    | YSC | Sherbrooke |
+    | YTQ | Tasiujaq |
+    | YUY | Rouyn-Noranda |
+    | YZV | Sept-Iles |
+    | YGP | Gaspe |
+    | YRQ | Trois-Rivieres |
+    | YBC | Baie-Comeau |
+
+??? note "British Columbia"
+
+    | Code | Region |
+    |------|--------|
+    | YVR | Vancouver |
+    | YYJ | Victoria |
+    | YXX | Abbotsford / Fraser Valley |
+    | YLW | Kelowna |
+    | YXS | Prince George |
+    | YPR | Prince Rupert |
+    | YXT | Terrace |
+    | YQQ | Comox / Courtenay |
+    | YCD | Nanaimo |
+    | YYD | Smithers |
+    | YDQ | Dawson Creek |
+    | YXJ | Fort St. John |
+    | YYF | Penticton |
+    | YCG | Castlegar |
+    | YKA | Kamloops |
+    | YXC | Cranbrook |
+
+??? note "Alberta"
+
+    | Code | Region |
+    |------|--------|
+    | YYC | Calgary |
+    | YEG | Edmonton |
+    | YMM | Fort McMurray |
+    | YQU | Grande Prairie |
+    | YQL | Lethbridge |
+    | YXH | Medicine Hat |
+
+??? note "Saskatchewan"
+
+    | Code | Region |
+    |------|--------|
+    | YQR | Regina |
+    | YXE | Saskatoon |
+    | YPA | Prince Albert |
+
+??? note "Manitoba"
+
+    | Code | Region |
+    |------|--------|
+    | YWG | Winnipeg |
+    | YBR | Brandon |
+    | YTH | Thompson |
+    | YDN | Dauphin |
+    | YPG | Portage la Prairie |
+
+??? note "New Brunswick"
+
+    | Code | Region |
+    |------|--------|
+    | YFC | Fredericton |
+    | YSJ | Saint John |
+    | YQM | Moncton |
+    | ZBF | Bathurst |
+
+??? note "Nova Scotia"
+
+    | Code | Region |
+    |------|--------|
+    | YHZ | Halifax |
+    | YQY | Sydney |
+    | YQI | Yarmouth |
+
+??? note "Prince Edward Island"
+
+    | Code | Region |
+    |------|--------|
+    | YYG | Charlottetown |
+
+??? note "Newfoundland and Labrador"
+
+    | Code | Region |
+    |------|--------|
+    | YYT | St. John's |
+    | YQX | Gander |
+    | YDF | Deer Lake |
+    | YYR | Goose Bay |
+    | YWK | Wabush |
+
+??? note "Territories (YT / NT / NU)"
+
+    | Code | Region |
+    |------|--------|
+    | YXY | Whitehorse (Yukon) |
+    | YZF | Yellowknife (NWT) |
+    | YFB | Iqaluit (Nunavut) |
+    | YEV | Inuvik (NWT) |
+    | YHY | Hay River (NWT) |

--- a/docs/analyzer/intro.md
+++ b/docs/analyzer/intro.md
@@ -1,13 +1,11 @@
 # Analyzer & MQTT Packet Broker
 
-MeshCore observers capture mesh traffic and publish it to MQTT brokers, feeding telemetry dashboards, maps, and packet inspectors. Pick one of the four observer paths below to start reporting to the MeshCore.ca network.
+MeshCore observers capture mesh traffic and publish packet telemetry to MQTT brokers, feeding CoreScope dashboards, maps, and packet inspectors. Pick the observer path that matches your hardware and host setup.
 
 !!! tip "Observer setup checklist"
     Every observer path needs the same basics: a MeshCore radio already on the MeshCore Canada network settings, a real 3-letter IATA airport code, the MeshCore.ca broker pair, JWT token authentication, TLS on port `443`, and packet publishing enabled. If the setup screen has two broker entries, use the same IATA code on both entries.
 
     MeshCore Canada network settings are **USA/Canada (Recommended)**, or raw radio values `910.525 MHz / 62.5 kHz / SF7 / CR5`, with 3-byte path hashes. Fresh 2026-05-21 and newer MeshCore.ca direct MQTT firmware already includes that radio preset and the broker pair; still set `set path.hash.mode 2`, IATA, WiFi, and packet publishing during onboarding. On older images, retained preferences, or generic CLI devices, also run `set radio 910.525,62.5,7,5`.
-
-    For Home Assistant, packet publishing means **Payload Mode** = `packet` or the older **Packets (Lets Mesh)** option enabled. For firmware, run the CLI command block in the firmware guide so path hash, `mqtt.packets`, `bridge.enabled`, `mqtt.rx`, and `mqtt.tx` are set.
 
 ## Choose Your Observer Path
 
@@ -17,19 +15,19 @@ MeshCore observers capture mesh traffic and publish it to MQTT brokers, feeding 
 
     ---
 
-    Flash observer firmware directly onto a board. Connects to WiFi and reports to MQTT with no host computer needed.
+    Flash observer firmware directly onto a WiFi-capable LoRa board. No host computer required after setup.
 
-    Best for: Heltec V3, V4, and other standalone ESP32 devices.
+    Best for: Heltec V3, Heltec V4 OLED, and other published direct MQTT targets.
 
     [:octicons-arrow-right-24: MQTT Firmware Guide](builds/mqtt-firmware.md)
 
--   :material-usb:{ .lg .middle } **MCtoMQTT (USB Host)**
+-   :material-usb:{ .lg .middle } **MCtoMQTT**
 
     ---
 
-    Bridge a USB-connected MeshCore node to MQTT via a Linux or macOS host. Also supports companion radios over BLE, serial, or TCP.
+    Bridge a USB-connected MeshCore node to MQTT via a Linux or macOS host.
 
-    Best for: Repeaters and room servers with a host machine.
+    Best for: fixed repeaters and room servers with a nearby host machine.
 
     [:octicons-arrow-right-24: MCtoMQTT Guide](builds/mctomqtt.md)
 
@@ -37,7 +35,7 @@ MeshCore observers capture mesh traffic and publish it to MQTT brokers, feeding 
 
     ---
 
-    Add the MeshCore.ca broker pair to an existing pyMC repeater installation via YAML config.
+    Add the MeshCore.ca broker pair to an existing pyMC repeater installation.
 
     Best for: Python-based repeater setups.
 
@@ -47,7 +45,7 @@ MeshCore observers capture mesh traffic and publish it to MQTT brokers, feeding 
 
     ---
 
-    Add MeshCore.ca brokers to the HA MeshCore integration for mesh telemetry on your dashboards.
+    Add MeshCore.ca brokers to the Home Assistant MeshCore integration.
 
     Best for: Home Assistant users with a connected MeshCore node.
 
@@ -57,15 +55,15 @@ MeshCore observers capture mesh traffic and publish it to MQTT brokers, feeding 
 
     ---
 
-    Use RemoteTerm's Community MQTT fanout to make a companion radio report raw packets to MeshCore.ca.
+    Use RemoteTerm's Community MQTT fanout to report packets from a managed radio.
 
-    Best for: RemoteTerm users already managing a radio over serial, TCP, or BLE.
+    Best for: RemoteTerm users already connected over serial, TCP, or BLE.
 
-    [:octicons-arrow-right-24: RemoteTerm Setup](#remoteterm-for-meshcore)
+    [:octicons-arrow-right-24: RemoteTerm Setup](remoteterm.md)
 
 </div>
 
----
+## Shared References
 
 <div class="grid cards" markdown>
 
@@ -73,198 +71,46 @@ MeshCore observers capture mesh traffic and publish it to MQTT brokers, feeding 
 
     ---
 
-    Confirm your observer is online and reporting to the MeshCore.ca network.
+    Confirm your observer is online and reporting to CoreScope.
 
     [:octicons-arrow-right-24: Check Your Observer](verify.md)
 
--   :material-server-network:{ .lg .middle } **Broker Details**
+-   :material-wrench:{ .lg .middle } **Troubleshooting**
 
     ---
 
-    All paths use the same redundant pair. JWT auth, TLS, no password needed.
+    Path-specific diagnostics for firmware, host bridges, PyMC, Home Assistant, and RemoteTerm.
 
-    `mqtt1.meshcore.ca` :octicons-arrow-switch-24: `mqtt2.meshcore.ca` (port 443, WSS)
+    [:octicons-arrow-right-24: Troubleshooting](troubleshooting.md)
+
+-   :material-server-network:{ .lg .middle } **Broker Reference**
+
+    ---
+
+    Broker hosts, ports, TLS, JWT audience, and topic conventions.
+
+    [:octicons-arrow-right-24: Broker Details](broker-reference.md)
+
+-   :material-airplane:{ .lg .middle } **IATA Codes**
+
+    ---
+
+    Canadian quick-list codes and guidance for choosing a real region code.
+
+    [:octicons-arrow-right-24: IATA Region Codes](iata-codes.md)
 
 </div>
 
----
+## Fast Path
 
-## RemoteTerm For MeshCore
+If you are unsure which path to choose:
 
-[RemoteTerm for MeshCore](https://github.com/jkingsman/Remote-Terminal-for-MeshCore) can act as an observer by forwarding raw RF packets through its **Community MQTT/meshcoretomqtt** integration. This does not publish decrypted messages.
+| Situation | Start here |
+|-----------|------------|
+| You have a WiFi-capable LoRa board and want a standalone observer | [MQTT Firmware](builds/mqtt-firmware.md) |
+| You have a repeater connected to a Linux/macOS host over USB | [MCtoMQTT](builds/mctomqtt.md) |
+| You already run pyMC | [PyMC](builds/pymc.md) |
+| You already use Home Assistant for MeshCore | [MeshCore-HA](builds/meshcore-ha.md) |
+| You already manage the radio with RemoteTerm | [RemoteTerm](remoteterm.md) |
 
-Install and start RemoteTerm using the upstream instructions, connect your MeshCore radio over serial, TCP, or BLE, then open the RemoteTerm web UI.
-
-In RemoteTerm, open **Settings** -> **MQTT & Automation**, add **Community MQTT/meshcoretomqtt**, and use these values:
-
-| Field | Value |
-|-------|-------|
-| Name | `MeshCore.ca 1` or any descriptive name |
-| Broker Host | `mqtt1.meshcore.ca` |
-| Broker Port | `443` |
-| Transport | `WebSockets` |
-| Authentication | `Token` |
-| WebSocket Path | `/` |
-| Token Audience | `mqtt1.meshcore.ca` or leave blank to default to the broker host |
-| Owner Email | Optional |
-| Use TLS | Enabled |
-| Verify TLS certificates | Enabled |
-| Region Code (IATA) | Your nearest real 3-letter IATA airport code |
-| Packet Topic Template | `meshcore/{IATA}/{PUBLIC_KEY}/packets` |
-
-Click **Save as Enabled**. To publish to the redundant broker as well, add a second Community MQTT integration with the same settings, but set **Broker Host** and **Token Audience** to `mqtt2.meshcore.ca`.
-
-![RemoteTerm Community MQTT settings for MeshCore.ca](../assets/mcterm.png)
-
-!!! note "Windows MQTT fanout"
-    If you run RemoteTerm on Windows and enable MQTT fanout, start Uvicorn with `--loop none` as described in the RemoteTerm README so the MQTT client can connect reliably.
-
----
-
-## IATA Region Codes
-
-Each observer identifies its region with a real 3-letter IATA airport code. Use the airport code nearest to your location.
-
-The firmware and helper scripts are not limited to the list below. If your nearest real IATA code is missing here, you can still use it and the public broker will accept it as long as it is a valid airport code. The live site will add observed regions to the picker automatically, but codes missing from the friendly-name list may appear as the bare code until we add a label.
-
-Do not use placeholders or made-up region names such as `XXX` or `HOME`. Do not use `CAN` as shorthand for Canada; it is a real airport code for Guangzhou and will tag your observer to the wrong region.
-
-The following Canadian codes are listed for quick selection today. Host-side helper scripts show this same list interactively when you omit `--iata`.
-
-??? note "Ontario"
-
-    | Code | Region |
-    |------|--------|
-    | YYZ | Toronto (Pearson) |
-    | YTZ | Toronto (Billy Bishop) |
-    | YOW | Ottawa |
-    | YHM | Hamilton |
-    | YKF | Kitchener / Waterloo |
-    | YXU | London |
-    | YOO | Oshawa |
-    | YKZ | Buttonville / Markham |
-    | YAM | Sault Ste. Marie |
-    | YQT | Thunder Bay |
-    | YSB | Sudbury |
-    | YTS | Timmins |
-    | YQG | Windsor |
-    | YYB | North Bay |
-    | YGK | Kingston |
-    | YPQ | Peterborough |
-    | YTR | Trenton / Quinte West |
-    | YHD | Dryden |
-    | YPL | Pickle Lake |
-    | YND | Gatineau (Ottawa area) |
-
-??? note "Quebec"
-
-    | Code | Region |
-    |------|--------|
-    | YUL | Montreal (Trudeau) |
-    | YMX | Montreal (Mirabel) |
-    | YQB | Quebec City |
-    | YBG | Bagotville / Saguenay |
-    | YVO | Val-d'Or |
-    | YHU | Montreal (St-Hubert) |
-    | YRJ | Roberval |
-    | YGL | La Grande Riviere |
-    | YSC | Sherbrooke |
-    | YTQ | Tasiujaq |
-    | YUY | Rouyn-Noranda |
-    | YZV | Sept-Iles |
-    | YGP | Gaspe |
-    | YRQ | Trois-Rivieres |
-
-??? note "British Columbia"
-
-    | Code | Region |
-    |------|--------|
-    | YVR | Vancouver |
-    | YYJ | Victoria |
-    | YXX | Abbotsford / Fraser Valley |
-    | YLW | Kelowna |
-    | YXS | Prince George |
-    | YPR | Prince Rupert |
-    | YXT | Terrace |
-    | YQQ | Comox / Courtenay |
-    | YCD | Nanaimo |
-    | YYD | Smithers |
-    | YDQ | Dawson Creek |
-    | YXJ | Fort St. John |
-    | YYF | Penticton |
-    | YCG | Castlegar |
-    | YKA | Kamloops |
-    | YXC | Cranbrook |
-    | YBC | Baie-Comeau |
-
-??? note "Alberta"
-
-    | Code | Region |
-    |------|--------|
-    | YYC | Calgary |
-    | YEG | Edmonton |
-    | YMM | Fort McMurray |
-    | YQU | Grande Prairie |
-    | YQL | Lethbridge |
-    | YXH | Medicine Hat |
-
-??? note "Saskatchewan"
-
-    | Code | Region |
-    |------|--------|
-    | YQR | Regina |
-    | YXE | Saskatoon |
-    | YPA | Prince Albert |
-
-??? note "Manitoba"
-
-    | Code | Region |
-    |------|--------|
-    | YWG | Winnipeg |
-    | YBR | Brandon |
-    | YTH | Thompson |
-    | YDN | Dauphin |
-    | YPG | Portage la Prairie |
-
-??? note "New Brunswick"
-
-    | Code | Region |
-    |------|--------|
-    | YFC | Fredericton |
-    | YSJ | Saint John |
-    | YQM | Moncton |
-    | ZBF | Bathurst |
-
-??? note "Nova Scotia"
-
-    | Code | Region |
-    |------|--------|
-    | YHZ | Halifax |
-    | YQY | Sydney |
-    | YQI | Yarmouth |
-
-??? note "Prince Edward Island"
-
-    | Code | Region |
-    |------|--------|
-    | YYG | Charlottetown |
-
-??? note "Newfoundland and Labrador"
-
-    | Code | Region |
-    |------|--------|
-    | YYT | St. John's |
-    | YQX | Gander |
-    | YDF | Deer Lake |
-    | YYR | Goose Bay |
-    | YWK | Wabush |
-
-??? note "Territories (YT / NT / NU)"
-
-    | Code | Region |
-    |------|--------|
-    | YXY | Whitehorse (Yukon) |
-    | YZF | Yellowknife (NWT) |
-    | YFB | Iqaluit (Nunavut) |
-    | YEV | Inuvik (NWT) |
-    | YHY | Hay River (NWT) |
+After setup, use [Check Your Observer](verify.md). If it does not appear within a few minutes, use [Troubleshooting](troubleshooting.md).

--- a/docs/analyzer/remoteterm.md
+++ b/docs/analyzer/remoteterm.md
@@ -1,0 +1,47 @@
+# RemoteTerm Setup
+
+[RemoteTerm for MeshCore](https://github.com/jkingsman/Remote-Terminal-for-MeshCore) can act as an observer by forwarding raw RF packets through its **Community MQTT / meshcoretomqtt** integration. This does not publish decrypted messages.
+
+Install and start RemoteTerm using the upstream instructions, connect your MeshCore radio over serial, TCP, or BLE, then open the RemoteTerm web UI.
+
+## Configure Community MQTT
+
+In RemoteTerm, open **Settings** -> **MQTT & Automation**, add **Community MQTT/meshcoretomqtt**, and use these values:
+
+| Field | Value |
+|-------|-------|
+| Name | `MeshCore.ca 1` or any descriptive name |
+| Broker Host | `mqtt1.meshcore.ca` |
+| Broker Port | `443` |
+| Transport | `WebSockets` |
+| Authentication | `Token` |
+| WebSocket Path | `/` |
+| Token Audience | `mqtt1.meshcore.ca` or leave blank to default to the broker host |
+| Owner Email | Optional |
+| Use TLS | Enabled |
+| Verify TLS certificates | Enabled |
+| Region Code (IATA) | Your nearest real 3-letter IATA airport code |
+| Packet Topic Template | `meshcore/{IATA}/{PUBLIC_KEY}/packets` |
+
+Click **Save as Enabled**.
+
+## Add the Backup Broker
+
+To publish to the redundant broker as well, add a second Community MQTT integration with the same settings, changing only:
+
+| Field | Value |
+|-------|-------|
+| Name | `MeshCore.ca 2` |
+| Broker Host | `mqtt2.meshcore.ca` |
+| Token Audience | `mqtt2.meshcore.ca` |
+
+Use the same IATA code on both entries.
+
+![RemoteTerm Community MQTT settings for MeshCore.ca](../assets/mcterm.png)
+
+!!! note "Windows MQTT fanout"
+    If you run RemoteTerm on Windows and enable MQTT fanout, start Uvicorn with `--loop none` as described in the RemoteTerm README so the MQTT client can connect reliably.
+
+## Verify
+
+After saving, use [Check Your Observer](verify.md). If the observer connects but no packets appear, confirm the radio is on the MeshCore Canada preset and that RemoteTerm is publishing packet topics, not only status.

--- a/docs/analyzer/scripts/setup-mqtt-firmware.ps1
+++ b/docs/analyzer/scripts/setup-mqtt-firmware.ps1
@@ -1,0 +1,593 @@
+param(
+    [string]$Board = "",
+    [string]$Role = "",
+    [string]$Iata = "",
+    [string]$Name = "",
+    [string]$WifiSsid = "",
+    [string]$WifiPassword = "",
+    [string]$Port = "",
+    [int]$Baud = 115200,
+    [double]$DelaySeconds = 0.25,
+    [switch]$PrintOnly,
+    [switch]$RestoreBrokers,
+    [switch]$NoRestoreBrokers,
+    [switch]$NoSetRadio,
+    [switch]$Repeat,
+    [switch]$ObserveOnly,
+    [switch]$ListIata,
+    [string]$Broker1Host = "mqtt1.meshcore.ca",
+    [string]$Broker2Host = "mqtt2.meshcore.ca"
+)
+
+$ErrorActionPreference = "Stop"
+$script:UsePrintOnly = $PrintOnly.IsPresent
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "[MeshCore.ca] $Message" -ForegroundColor Cyan
+}
+
+function Prompt-YesNo {
+    param(
+        [string]$Prompt,
+        [bool]$DefaultYes = $true
+    )
+    $suffix = if ($DefaultYes) { "[Y/n]" } else { "[y/N]" }
+    $answer = Read-Host "$Prompt $suffix"
+    if ([string]::IsNullOrWhiteSpace($answer)) {
+        return $DefaultYes
+    }
+    switch ($answer.Trim().ToLowerInvariant()) {
+        "y" { return $true }
+        "yes" { return $true }
+        default { return $false }
+    }
+}
+
+function Read-SecretPlainText {
+    param([string]$Prompt)
+    $secure = Read-Host $Prompt -AsSecureString
+    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+    try {
+        return [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+    }
+    finally {
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+    }
+}
+
+$IataChoices = @"
+Ontario|YYZ|Toronto (Pearson)
+Ontario|YTZ|Toronto (Billy Bishop)
+Ontario|YOW|Ottawa
+Ontario|YHM|Hamilton
+Ontario|YKF|Kitchener / Waterloo
+Ontario|YXU|London
+Ontario|YOO|Oshawa
+Ontario|YKZ|Buttonville / Markham
+Ontario|YAM|Sault Ste. Marie
+Ontario|YQT|Thunder Bay
+Ontario|YSB|Sudbury
+Ontario|YTS|Timmins
+Ontario|YQG|Windsor
+Ontario|YYB|North Bay
+Ontario|YGK|Kingston
+Ontario|YPQ|Peterborough
+Ontario|YTR|Trenton / Quinte West
+Ontario|YHD|Dryden
+Ontario|YPL|Pickle Lake
+Ontario|YND|Gatineau (Ottawa area)
+Quebec|YUL|Montreal (Trudeau)
+Quebec|YMX|Montreal (Mirabel)
+Quebec|YQB|Quebec City
+Quebec|YBG|Bagotville / Saguenay
+Quebec|YVO|Val-d'Or
+Quebec|YHU|Montreal (St-Hubert)
+Quebec|YRJ|Roberval
+Quebec|YGL|La Grande Riviere
+Quebec|YSC|Sherbrooke
+Quebec|YTQ|Tasiujaq
+Quebec|YUY|Rouyn-Noranda
+Quebec|YZV|Sept-Iles
+Quebec|YGP|Gaspe
+Quebec|YRQ|Trois-Rivieres
+British Columbia|YVR|Vancouver
+British Columbia|YYJ|Victoria
+British Columbia|YXX|Abbotsford / Fraser Valley
+British Columbia|YLW|Kelowna
+British Columbia|YXS|Prince George
+British Columbia|YPR|Prince Rupert
+British Columbia|YXT|Terrace
+British Columbia|YQQ|Comox / Courtenay
+British Columbia|YCD|Nanaimo
+British Columbia|YYD|Smithers
+British Columbia|YDQ|Dawson Creek
+British Columbia|YXJ|Fort St. John
+British Columbia|YYF|Penticton
+British Columbia|YCG|Castlegar
+British Columbia|YKA|Kamloops
+British Columbia|YXC|Cranbrook
+Alberta|YYC|Calgary
+Alberta|YEG|Edmonton
+Alberta|YMM|Fort McMurray
+Alberta|YQU|Grande Prairie
+Alberta|YQL|Lethbridge
+Alberta|YXH|Medicine Hat
+Saskatchewan|YQR|Regina
+Saskatchewan|YXE|Saskatoon
+Saskatchewan|YPA|Prince Albert
+Manitoba|YWG|Winnipeg
+Manitoba|YBR|Brandon
+Manitoba|YTH|Thompson
+Manitoba|YDN|Dauphin
+Manitoba|YPG|Portage la Prairie
+New Brunswick|YFC|Fredericton
+New Brunswick|YSJ|Saint John
+New Brunswick|YQM|Moncton
+New Brunswick|ZBF|Bathurst
+Nova Scotia|YHZ|Halifax
+Nova Scotia|YQY|Sydney
+Nova Scotia|YQI|Yarmouth
+Prince Edward Island|YYG|Charlottetown
+Newfoundland and Labrador|YYT|St. John's
+Newfoundland and Labrador|YQX|Gander
+Newfoundland and Labrador|YDF|Deer Lake
+Newfoundland and Labrador|YYR|Goose Bay
+Newfoundland and Labrador|YWK|Wabush
+Territories|YXY|Whitehorse (Yukon)
+Territories|YZF|Yellowknife (NWT)
+Territories|YFB|Iqaluit (Nunavut)
+Territories|YEV|Inuvik (NWT)
+Territories|YHY|Hay River (NWT)
+"@ -split "`n" | ForEach-Object {
+    $parts = $_.Trim() -split "\|"
+    if ($parts.Count -eq 3) {
+        [PSCustomObject]@{
+            Province = $parts[0]
+            Code = $parts[1]
+            Label = $parts[2]
+        }
+    }
+}
+
+function Show-IataChoices {
+    $last = ""
+    $index = 0
+    foreach ($item in $IataChoices) {
+        if ($item.Province -ne $last) {
+            Write-Host ""
+            Write-Host $item.Province
+            $last = $item.Province
+        }
+        $index += 1
+        Write-Host ("  {0,2}) {1}  {2}" -f $index, $item.Code, $item.Label)
+    }
+}
+
+function Get-IataByNumber {
+    param([int]$Number)
+    if ($Number -lt 1 -or $Number -gt $IataChoices.Count) {
+        return ""
+    }
+    return $IataChoices[$Number - 1].Code
+}
+
+function Get-IataLabel {
+    param([string]$Code)
+    $match = $IataChoices | Where-Object { $_.Code -eq $Code } | Select-Object -First 1
+    if ($null -eq $match) {
+        return ""
+    }
+    return $match.Label
+}
+
+function Resolve-Iata {
+    param([string]$Value)
+    $prompted = [string]::IsNullOrWhiteSpace($Value)
+    while ($true) {
+        if ([string]::IsNullOrWhiteSpace($Value)) {
+            Write-Info "Choose the real IATA airport code nearest to the observer."
+            Write-Info "Type a number from the quick list, or type any real 3-letter IATA code."
+            Write-Info "Do not use CAN as shorthand for Canada; CAN is an airport code in Guangzhou."
+            Show-IataChoices
+            $Value = Read-Host "IATA code or list number"
+            $prompted = $true
+        }
+
+        $candidate = $Value.Trim().ToUpperInvariant()
+        if ($candidate -match '^[0-9]+$') {
+            $candidate = Get-IataByNumber -Number ([int]$candidate)
+            if ([string]::IsNullOrWhiteSpace($candidate)) {
+                Write-Warning "No IATA quick-list item number: $Value"
+                $Value = ""
+                continue
+            }
+        }
+
+        if ($candidate -in @("XXX", "HOME", "CAN")) {
+            Write-Warning "$candidate is not a valid MeshCore.ca region choice. Use the real IATA airport code nearest to you."
+            $Value = ""
+            continue
+        }
+        if ($candidate -notmatch '^[A-Z]{3}$') {
+            Write-Warning "IATA code must be exactly 3 letters."
+            $Value = ""
+            continue
+        }
+
+        $label = Get-IataLabel -Code $candidate
+        if (-not [string]::IsNullOrWhiteSpace($label)) {
+            Write-Info "Region selected: $candidate ($label)"
+            return $candidate
+        }
+
+        Write-Warning "$candidate is not in the MeshCore.ca Canadian quick list."
+        Write-Warning "Continue only if $candidate is a real IATA airport code."
+        if (-not $prompted -or (Prompt-YesNo "Use $candidate anyway?" $false)) {
+            return $candidate
+        }
+        $Value = ""
+    }
+}
+
+function Normalize-Board {
+    param([string]$Value)
+    switch ($Value.Trim().ToLowerInvariant()) {
+        "1" { return "heltec-v3" }
+        "v3" { return "heltec-v3" }
+        "heltec-v3" { return "heltec-v3" }
+        "heltecv3" { return "heltec-v3" }
+        "2" { return "heltec-v4-oled" }
+        "v4" { return "heltec-v4-oled" }
+        "heltec-v4" { return "heltec-v4-oled" }
+        "heltec-v4-oled" { return "heltec-v4-oled" }
+        "heltecv4" { return "heltec-v4-oled" }
+        "heltecv4oled" { return "heltec-v4-oled" }
+        default { return "" }
+    }
+}
+
+function Resolve-Board {
+    param([string]$Value)
+    while ($true) {
+        if ([string]::IsNullOrWhiteSpace($Value)) {
+            Write-Host ""
+            Write-Host "Board:"
+            Write-Host "  1) Heltec V3"
+            Write-Host "  2) Heltec V4 OLED"
+            $Value = Read-Host "Board [1]"
+            if ([string]::IsNullOrWhiteSpace($Value)) {
+                $Value = "1"
+            }
+        }
+        $normalized = Normalize-Board -Value $Value
+        if (-not [string]::IsNullOrWhiteSpace($normalized)) {
+            return $normalized
+        }
+        Write-Warning "Board must be Heltec V3 or Heltec V4 OLED."
+        $Value = ""
+    }
+}
+
+function Normalize-Role {
+    param([string]$Value)
+    switch ($Value.Trim().ToLowerInvariant()) {
+        "1" { return "repeater" }
+        "repeater" { return "repeater" }
+        "repeat" { return "repeater" }
+        "2" { return "room-server" }
+        "room" { return "room-server" }
+        "room-server" { return "room-server" }
+        "room_server" { return "room-server" }
+        "roomserver" { return "room-server" }
+        default { return "" }
+    }
+}
+
+function Resolve-Role {
+    param([string]$Value)
+    while ($true) {
+        if ([string]::IsNullOrWhiteSpace($Value)) {
+            Write-Host ""
+            Write-Host "Role:"
+            Write-Host "  1) Repeater"
+            Write-Host "  2) Room Server"
+            $Value = Read-Host "Role [1]"
+            if ([string]::IsNullOrWhiteSpace($Value)) {
+                $Value = "1"
+            }
+        }
+        $normalized = Normalize-Role -Value $Value
+        if (-not [string]::IsNullOrWhiteSpace($normalized)) {
+            return $normalized
+        }
+        Write-Warning "Role must be repeater or room-server."
+        $Value = ""
+    }
+}
+
+function Get-RoleLabelForName {
+    param([string]$Role)
+    if ($Role -eq "room-server") {
+        return "Room-Server"
+    }
+    return "Repeater"
+}
+
+function Resolve-RequiredText {
+    param(
+        [string]$Value,
+        [string]$Prompt,
+        [switch]$Secret
+    )
+    while ([string]::IsNullOrWhiteSpace($Value)) {
+        if ($Secret.IsPresent) {
+            $Value = Read-SecretPlainText -Prompt $Prompt
+        }
+        else {
+            $Value = Read-Host $Prompt
+        }
+    }
+    if ($Value -match "[`r`n]") {
+        throw "$Prompt cannot contain newlines."
+    }
+    return $Value
+}
+
+function Resolve-NodeName {
+    param(
+        [string]$Value,
+        [string]$Iata,
+        [string]$Role
+    )
+    $defaultName = "$Iata-$(Get-RoleLabelForName -Role $Role)-01"
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        $answer = Read-Host "MeshCore node name [$defaultName]"
+        if ([string]::IsNullOrWhiteSpace($answer)) {
+            $Value = $defaultName
+        }
+        else {
+            $Value = $answer
+        }
+    }
+    if ($Value -match "[`r`n]") {
+        throw "Node name cannot contain newlines."
+    }
+    return $Value
+}
+
+function Resolve-RestoreBrokers {
+    if ($RestoreBrokers.IsPresent -and $NoRestoreBrokers.IsPresent) {
+        throw "Use only one of -RestoreBrokers or -NoRestoreBrokers."
+    }
+    if ($RestoreBrokers.IsPresent) {
+        return $true
+    }
+    if ($NoRestoreBrokers.IsPresent) {
+        return $false
+    }
+    return (Prompt-YesNo "Restore MeshCore.ca broker slots? This sets slots 1-2 and disables slots 3-6." $true)
+}
+
+function Resolve-RepeatMode {
+    if ($Repeat.IsPresent -and $ObserveOnly.IsPresent) {
+        throw "Use only one of -Repeat or -ObserveOnly."
+    }
+    if ($Repeat.IsPresent) {
+        return "on"
+    }
+    if ($ObserveOnly.IsPresent) {
+        return "off"
+    }
+    if (Prompt-YesNo "Should this device repeat packets for the local mesh?" $true) {
+        return "on"
+    }
+    return "off"
+}
+
+function Get-SerialPorts {
+    try {
+        return [System.IO.Ports.SerialPort]::GetPortNames() | Sort-Object
+    }
+    catch {
+        return @()
+    }
+}
+
+function Resolve-Port {
+    param([string]$Value)
+    if ($script:UsePrintOnly) {
+        return ""
+    }
+    if (-not [string]::IsNullOrWhiteSpace($Value)) {
+        return $Value
+    }
+
+    $ports = @(Get-SerialPorts)
+    if ($ports.Count -eq 0) {
+        Write-Info "No COM port was auto-detected."
+        if (Prompt-YesNo "Print commands instead of sending over serial?" $true) {
+            $script:UsePrintOnly = $true
+            return ""
+        }
+        return (Read-Host "COM port, e.g. COM3")
+    }
+
+    Write-Info "Detected serial ports:"
+    for ($i = 0; $i -lt $ports.Count; $i++) {
+        Write-Host ("  {0}) {1}" -f ($i + 1), $ports[$i])
+    }
+    $choice = Read-Host "COM port number, name, or 'print'"
+    if ([string]::IsNullOrWhiteSpace($choice) -and $ports.Count -eq 1) {
+        return $ports[0]
+    }
+    if ($choice.Trim().ToLowerInvariant() -eq "print") {
+        $script:UsePrintOnly = $true
+        return ""
+    }
+    if ($choice -match '^[0-9]+$') {
+        $index = [int]$choice
+        if ($index -ge 1 -and $index -le $ports.Count) {
+            return $ports[$index - 1]
+        }
+        throw "No COM port item number: $choice"
+    }
+    return $choice
+}
+
+function New-SetupCommands {
+    param(
+        [string]$NodeName,
+        [string]$Iata,
+        [string]$WifiSsid,
+        [string]$WifiPassword,
+        [bool]$SetRadio,
+        [bool]$RestoreBrokerSlots,
+        [string]$RepeatMode
+    )
+    $commands = New-Object System.Collections.Generic.List[string]
+    $commands.Add("set name $NodeName")
+    if ($SetRadio) {
+        $commands.Add("set radio 910.525,62.5,7,5")
+    }
+    $commands.Add("set path.hash.mode 2")
+    $commands.Add("set mqtt.iata $Iata")
+    $commands.Add("set wifi.ssid $WifiSsid")
+    $commands.Add("set wifi.pwd $WifiPassword")
+    $commands.Add("set wifi.powersave none")
+    $commands.Add("set mqtt.status on")
+    $commands.Add("set mqtt.packets on")
+    $commands.Add("set bridge.enabled on")
+    $commands.Add("set mqtt.rx on")
+    $commands.Add("set mqtt.tx advert")
+
+    if ($RestoreBrokerSlots) {
+        $commands.Add("set mqtt1.preset none")
+        $commands.Add("set mqtt2.preset none")
+        $commands.Add("set mqtt3.preset none")
+        $commands.Add("set mqtt4.preset none")
+        $commands.Add("set mqtt5.preset none")
+        $commands.Add("set mqtt6.preset none")
+        $commands.Add("set mqtt1.preset custom")
+        $commands.Add("set mqtt1.server wss://$Broker1Host`:443")
+        $commands.Add("set mqtt1.port 443")
+        $commands.Add("set mqtt1.audience $Broker1Host")
+        $commands.Add("set mqtt2.preset custom")
+        $commands.Add("set mqtt2.server wss://$Broker2Host`:443")
+        $commands.Add("set mqtt2.port 443")
+        $commands.Add("set mqtt2.audience $Broker2Host")
+    }
+
+    if ($RepeatMode -eq "off") {
+        $commands.Add("set repeat off")
+    }
+    $commands.Add("reboot")
+    return $commands.ToArray()
+}
+
+function Write-CommandBlock {
+    param(
+        [string[]]$Commands,
+        [switch]$MaskPassword
+    )
+    Write-Host '```text'
+    foreach ($command in $Commands) {
+        if ($MaskPassword.IsPresent -and $command.StartsWith("set wifi.pwd ")) {
+            Write-Host "set wifi.pwd ********"
+        }
+        else {
+            Write-Host $command
+        }
+    }
+    Write-Host '```'
+}
+
+function Send-Commands {
+    param(
+        [string]$Port,
+        [int]$Baud,
+        [string[]]$Commands,
+        [double]$DelaySeconds
+    )
+    $serial = New-Object System.IO.Ports.SerialPort $Port, $Baud, "None", 8, "One"
+    $serial.NewLine = "`r`n"
+    $serial.WriteTimeout = 5000
+    try {
+        $serial.Open()
+        foreach ($command in $Commands) {
+            if ($command.StartsWith("set wifi.pwd ")) {
+                Write-Info "Sending: set wifi.pwd ********"
+            }
+            else {
+                Write-Info "Sending: $command"
+            }
+            $serial.WriteLine($command)
+            Start-Sleep -Milliseconds ([int]($DelaySeconds * 1000))
+        }
+    }
+    finally {
+        if ($serial.IsOpen) {
+            $serial.Close()
+        }
+    }
+}
+
+if ($ListIata.IsPresent) {
+    Show-IataChoices
+    exit 0
+}
+
+$Board = Resolve-Board -Value $Board
+$Role = Resolve-Role -Value $Role
+$Iata = Resolve-Iata -Value $Iata
+$Name = Resolve-NodeName -Value $Name -Iata $Iata -Role $Role
+$WifiSsid = Resolve-RequiredText -Value $WifiSsid -Prompt "2.4 GHz WiFi SSID"
+$WifiPassword = Resolve-RequiredText -Value $WifiPassword -Prompt "2.4 GHz WiFi password" -Secret
+$restoreBrokerSlots = Resolve-RestoreBrokers
+$repeatModeValue = Resolve-RepeatMode
+$Port = Resolve-Port -Value $Port
+
+$commands = New-SetupCommands `
+    -NodeName $Name `
+    -Iata $Iata `
+    -WifiSsid $WifiSsid `
+    -WifiPassword $WifiPassword `
+    -SetRadio (-not $NoSetRadio.IsPresent) `
+    -RestoreBrokerSlots $restoreBrokerSlots `
+    -RepeatMode $repeatModeValue
+
+Write-Host ""
+Write-Info "Setup summary:"
+Write-Info "Board: $Board"
+Write-Info "Role: $Role"
+Write-Info "Name: $Name"
+Write-Info "IATA: $Iata"
+Write-Info "WiFi SSID: $WifiSsid"
+Write-Info "Restore brokers: $restoreBrokerSlots"
+Write-Info "Repeat packets: $repeatModeValue"
+
+if ($script:UsePrintOnly) {
+    Write-Info "Mode: print commands only"
+    Write-Host ""
+    Write-Host "Copy/paste these commands into the MeshCore admin CLI:"
+    Write-Host ""
+    Write-CommandBlock -Commands $commands
+}
+else {
+    Write-Info "COM port: $Port"
+    Write-Host ""
+    Write-Host "Commands to be sent:"
+    Write-Host ""
+    Write-CommandBlock -Commands $commands -MaskPassword
+    Write-Host ""
+    if (Prompt-YesNo "Send these commands to $Port now?" $true) {
+        Send-Commands -Port $Port -Baud $Baud -Commands $commands -DelaySeconds $DelaySeconds
+        Write-Info "Commands sent. The device should reboot."
+    }
+    else {
+        Write-Info "Canceled before sending. Re-run with -PrintOnly to copy commands manually."
+        exit 1
+    }
+}
+
+Write-Info "Done. After reboot, check https://live.meshcore.ca/#/observers for $Name."

--- a/docs/analyzer/scripts/setup-mqtt-firmware.sh
+++ b/docs/analyzer/scripts/setup-mqtt-firmware.sh
@@ -1,0 +1,667 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BOARD="${MESHCORE_CA_BOARD:-}"
+ROLE="${MESHCORE_CA_ROLE:-}"
+IATA="${MESHCORE_CA_IATA:-}"
+NODE_NAME="${MESHCORE_CA_NODE_NAME:-}"
+WIFI_SSID="${MESHCORE_CA_WIFI_SSID:-}"
+WIFI_PASSWORD="${MESHCORE_CA_WIFI_PASSWORD:-}"
+SERIAL_PORT="${MESHCORE_CA_SERIAL_PORT:-}"
+BAUD="${MESHCORE_CA_BAUD:-115200}"
+COMMAND_DELAY="${MESHCORE_CA_COMMAND_DELAY:-0.25}"
+PRINT_ONLY=0
+RESTORE_BROKERS="${MESHCORE_CA_RESTORE_BROKERS:-ask}"
+SET_RADIO="${MESHCORE_CA_SET_RADIO:-1}"
+REPEAT_MODE="${MESHCORE_CA_REPEAT:-ask}"
+
+BROKER1_HOST="${MESHCORE_CA_MQTT1_HOST:-mqtt1.meshcore.ca}"
+BROKER2_HOST="${MESHCORE_CA_MQTT2_HOST:-mqtt2.meshcore.ca}"
+
+usage() {
+  cat <<EOF
+Guided setup for MeshCore.ca direct MQTT firmware on Heltec V3/V4 boards.
+
+Usage:
+  bash <(curl -fsSL https://meshcore.ca/analyzer/scripts/setup-mqtt-firmware.sh)
+  bash setup-mqtt-firmware.sh --port /dev/ttyUSB0
+  bash setup-mqtt-firmware.sh --print-only --iata YOW --wifi-ssid MyWiFi
+
+Options:
+  --board VALUE          heltec-v3 | heltec-v4-oled
+  --role VALUE           repeater | room-server
+  --iata CODE            Real 3-letter IATA airport code.
+  --name NAME            MeshCore node name, e.g. YOW-Repeater-01.
+  --wifi-ssid SSID       2.4 GHz WiFi SSID.
+  --wifi-password PASS   2.4 GHz WiFi password.
+  --port PATH            Serial port, e.g. /dev/ttyUSB0 or /dev/cu.usbmodem101.
+  --baud RATE            Serial baud rate. Default: 115200.
+  --print-only           Print CLI commands instead of sending over serial.
+  --restore-brokers      Overwrite broker slots 1 and 2 with MeshCore.ca brokers.
+  --no-restore-brokers   Leave broker slots as flashed.
+  --set-radio            Send the MeshCore Canada radio values. Default.
+  --no-set-radio         Do not send set radio.
+  --repeat               Leave packet repeating enabled.
+  --observe-only         Send set repeat off.
+  --list-iata            Show common Canadian IATA choices and exit.
+  --help                 Show this help.
+
+Environment variables with matching names are also supported:
+  MESHCORE_CA_BOARD, MESHCORE_CA_ROLE, MESHCORE_CA_IATA,
+  MESHCORE_CA_NODE_NAME, MESHCORE_CA_WIFI_SSID,
+  MESHCORE_CA_WIFI_PASSWORD, MESHCORE_CA_SERIAL_PORT.
+EOF
+}
+
+say() {
+  printf '[MeshCore.ca] %s\n' "$*"
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+have_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+need_tty() {
+  [ -t 0 ] || die "Missing required values and no interactive terminal is available. Re-run with --help for non-interactive flags."
+}
+
+prompt_text() {
+  local prompt="$1"
+  local default="${2:-}"
+  local value=""
+  need_tty
+  if [ -n "$default" ]; then
+    printf '%s [%s]: ' "$prompt" "$default"
+  else
+    printf '%s: ' "$prompt"
+  fi
+  read -r value
+  printf '%s\n' "${value:-$default}"
+}
+
+prompt_secret() {
+  local prompt="$1"
+  local value=""
+  need_tty
+  printf '%s: ' "$prompt"
+  stty -echo 2>/dev/null || true
+  read -r value
+  stty echo 2>/dev/null || true
+  printf '\n'
+  printf '%s\n' "$value"
+}
+
+prompt_yes_no() {
+  local prompt="$1"
+  local default="${2:-y}"
+  local answer=""
+  need_tty
+  if [ "$default" = "y" ]; then
+    printf '%s [Y/n] ' "$prompt"
+  else
+    printf '%s [y/N] ' "$prompt"
+  fi
+  read -r answer
+  answer="$(printf '%s' "${answer:-$default}" | tr '[:upper:]' '[:lower:]')"
+  case "$answer" in
+    y|yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+upper_iata() {
+  printf '%s' "$1" | tr '[:lower:]' '[:upper:]'
+}
+
+IATA_CHOICES="$(cat <<'EOF'
+Ontario|YYZ|Toronto (Pearson)
+Ontario|YTZ|Toronto (Billy Bishop)
+Ontario|YOW|Ottawa
+Ontario|YHM|Hamilton
+Ontario|YKF|Kitchener / Waterloo
+Ontario|YXU|London
+Ontario|YOO|Oshawa
+Ontario|YKZ|Buttonville / Markham
+Ontario|YAM|Sault Ste. Marie
+Ontario|YQT|Thunder Bay
+Ontario|YSB|Sudbury
+Ontario|YTS|Timmins
+Ontario|YQG|Windsor
+Ontario|YYB|North Bay
+Ontario|YGK|Kingston
+Ontario|YPQ|Peterborough
+Ontario|YTR|Trenton / Quinte West
+Ontario|YHD|Dryden
+Ontario|YPL|Pickle Lake
+Ontario|YND|Gatineau (Ottawa area)
+Quebec|YUL|Montreal (Trudeau)
+Quebec|YMX|Montreal (Mirabel)
+Quebec|YQB|Quebec City
+Quebec|YBG|Bagotville / Saguenay
+Quebec|YVO|Val-d'Or
+Quebec|YHU|Montreal (St-Hubert)
+Quebec|YRJ|Roberval
+Quebec|YGL|La Grande Riviere
+Quebec|YSC|Sherbrooke
+Quebec|YTQ|Tasiujaq
+Quebec|YUY|Rouyn-Noranda
+Quebec|YZV|Sept-Iles
+Quebec|YGP|Gaspe
+Quebec|YRQ|Trois-Rivieres
+British Columbia|YVR|Vancouver
+British Columbia|YYJ|Victoria
+British Columbia|YXX|Abbotsford / Fraser Valley
+British Columbia|YLW|Kelowna
+British Columbia|YXS|Prince George
+British Columbia|YPR|Prince Rupert
+British Columbia|YXT|Terrace
+British Columbia|YQQ|Comox / Courtenay
+British Columbia|YCD|Nanaimo
+British Columbia|YYD|Smithers
+British Columbia|YDQ|Dawson Creek
+British Columbia|YXJ|Fort St. John
+British Columbia|YYF|Penticton
+British Columbia|YCG|Castlegar
+British Columbia|YKA|Kamloops
+British Columbia|YXC|Cranbrook
+Alberta|YYC|Calgary
+Alberta|YEG|Edmonton
+Alberta|YMM|Fort McMurray
+Alberta|YQU|Grande Prairie
+Alberta|YQL|Lethbridge
+Alberta|YXH|Medicine Hat
+Saskatchewan|YQR|Regina
+Saskatchewan|YXE|Saskatoon
+Saskatchewan|YPA|Prince Albert
+Manitoba|YWG|Winnipeg
+Manitoba|YBR|Brandon
+Manitoba|YTH|Thompson
+Manitoba|YDN|Dauphin
+Manitoba|YPG|Portage la Prairie
+New Brunswick|YFC|Fredericton
+New Brunswick|YSJ|Saint John
+New Brunswick|YQM|Moncton
+New Brunswick|ZBF|Bathurst
+Nova Scotia|YHZ|Halifax
+Nova Scotia|YQY|Sydney
+Nova Scotia|YQI|Yarmouth
+Prince Edward Island|YYG|Charlottetown
+Newfoundland and Labrador|YYT|St. John's
+Newfoundland and Labrador|YQX|Gander
+Newfoundland and Labrador|YDF|Deer Lake
+Newfoundland and Labrador|YYR|Goose Bay
+Newfoundland and Labrador|YWK|Wabush
+Territories|YXY|Whitehorse (Yukon)
+Territories|YZF|Yellowknife (NWT)
+Territories|YFB|Iqaluit (Nunavut)
+Territories|YEV|Inuvik (NWT)
+Territories|YHY|Hay River (NWT)
+EOF
+)"
+
+print_iata_choices() {
+  local last="" n=0
+  printf '%s\n' "$IATA_CHOICES" | while IFS='|' read -r province code label; do
+    [ -n "$province" ] || continue
+    if [ "$province" != "$last" ]; then
+      printf '\n%s\n' "$province"
+      last="$province"
+    fi
+    n=$((n + 1))
+    printf '  %2d) %s  %s\n' "$n" "$code" "$label"
+  done
+}
+
+iata_by_number() {
+  printf '%s\n' "$IATA_CHOICES" | awk -F'|' -v wanted="$1" '
+    NF == 3 {
+      n++
+      if (n == wanted) {
+        print $2
+        found = 1
+        exit
+      }
+    }
+    END { if (!found) exit 1 }
+  '
+}
+
+known_iata_label() {
+  printf '%s\n' "$IATA_CHOICES" | awk -F'|' -v code="$1" '
+    toupper($2) == code {
+      print $3
+      found = 1
+      exit
+    }
+    END { if (!found) exit 1 }
+  '
+}
+
+prompt_iata() {
+  local choice selected
+  say "Choose the real IATA airport code nearest to the observer."
+  say "Type a number from the quick list, or type any real 3-letter IATA code."
+  say "Do not use CAN as shorthand for Canada; CAN is an airport code in Guangzhou."
+  print_iata_choices
+  while :; do
+    printf '\nIATA code or list number: '
+    read -r choice
+    choice="$(printf '%s' "$choice" | tr '[:lower:]' '[:upper:]' | tr -d '[:space:]')"
+    [ -n "$choice" ] || continue
+    if printf '%s' "$choice" | grep -Eq '^[0-9]+$'; then
+      selected="$(iata_by_number "$choice" || true)"
+      if [ -n "$selected" ]; then
+        IATA="$selected"
+        return 0
+      fi
+      echo "No IATA quick-list item number: $choice" >&2
+      continue
+    fi
+    IATA="$choice"
+    return 0
+  done
+}
+
+require_iata() {
+  local label
+  while :; do
+    if [ -z "$IATA" ]; then
+      need_tty
+      prompt_iata
+    fi
+    IATA="$(upper_iata "$IATA" | tr -d '[:space:]')"
+    case "$IATA" in
+      XXX|HOME|CAN)
+        echo "$IATA is not a valid MeshCore.ca region choice. Use the real IATA airport code nearest to you." >&2
+        IATA=""
+        continue
+        ;;
+    esac
+    if ! printf '%s' "$IATA" | grep -Eq '^[A-Z]{3}$'; then
+      echo "IATA code must be exactly 3 letters, got: $IATA" >&2
+      IATA=""
+      continue
+    fi
+    if label="$(known_iata_label "$IATA" 2>/dev/null)"; then
+      say "Region selected: $IATA ($label)"
+      return 0
+    fi
+    say "$IATA is not in the MeshCore.ca quick list."
+    say "Continue only if $IATA is a real IATA airport code."
+    if [ ! -t 0 ]; then
+      return 0
+    fi
+    if prompt_yes_no "Use $IATA anyway?" "n"; then
+      return 0
+    fi
+    IATA=""
+  done
+}
+
+normalize_board() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    1|v3|heltec-v3|heltecv3)
+      printf 'heltec-v3'
+      ;;
+    2|v4|heltec-v4|heltec-v4-oled|heltecv4|heltecv4oled)
+      printf 'heltec-v4-oled'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+normalize_role() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    1|repeater|repeat)
+      printf 'repeater'
+      ;;
+    2|room|room-server|room_server|roomserver)
+      printf 'room-server'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+choose_board() {
+  local choice normalized
+  while :; do
+    if [ -n "$BOARD" ]; then
+      normalized="$(normalize_board "$BOARD" || true)"
+      [ -n "$normalized" ] || die "--board must be heltec-v3 or heltec-v4-oled"
+      BOARD="$normalized"
+      return 0
+    fi
+    need_tty
+    printf '\nBoard:\n'
+    printf '  1) Heltec V3\n'
+    printf '  2) Heltec V4 OLED\n'
+    printf 'Board [1]: '
+    read -r choice
+    BOARD="${choice:-1}"
+  done
+}
+
+choose_role() {
+  local choice normalized
+  while :; do
+    if [ -n "$ROLE" ]; then
+      normalized="$(normalize_role "$ROLE" || true)"
+      [ -n "$normalized" ] || die "--role must be repeater or room-server"
+      ROLE="$normalized"
+      return 0
+    fi
+    need_tty
+    printf '\nRole:\n'
+    printf '  1) Repeater\n'
+    printf '  2) Room Server\n'
+    printf 'Role [1]: '
+    read -r choice
+    ROLE="${choice:-1}"
+  done
+}
+
+role_label_for_name() {
+  if [ "$ROLE" = "room-server" ]; then
+    printf 'Room-Server'
+  else
+    printf 'Repeater'
+  fi
+}
+
+require_clean_value() {
+  local name="$1"
+  local value="$2"
+  if printf '%s' "$value" | grep -q '[[:cntrl:]]'; then
+    die "$name cannot contain control characters."
+  fi
+}
+
+require_wifi() {
+  while [ -z "$WIFI_SSID" ]; do
+    WIFI_SSID="$(prompt_text "2.4 GHz WiFi SSID")"
+  done
+  require_clean_value "WiFi SSID" "$WIFI_SSID"
+
+  while [ -z "$WIFI_PASSWORD" ]; do
+    WIFI_PASSWORD="$(prompt_secret "2.4 GHz WiFi password")"
+  done
+  require_clean_value "WiFi password" "$WIFI_PASSWORD"
+}
+
+choose_name() {
+  local default_name
+  default_name="${IATA}-$(role_label_for_name)-01"
+  if [ -z "$NODE_NAME" ]; then
+    NODE_NAME="$(prompt_text "MeshCore node name" "$default_name")"
+  fi
+  [ -n "$NODE_NAME" ] || die "Node name is required."
+  require_clean_value "Node name" "$NODE_NAME"
+}
+
+resolve_bool() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|y|on) return 0 ;;
+    0|false|no|n|off) return 1 ;;
+    *) return 2 ;;
+  esac
+}
+
+choose_restore_brokers() {
+  if [ "$RESTORE_BROKERS" = "ask" ]; then
+    if prompt_yes_no "Restore MeshCore.ca broker slots? This sets slots 1-2 and disables slots 3-6." "y"; then
+      RESTORE_BROKERS=1
+    else
+      RESTORE_BROKERS=0
+    fi
+  fi
+  if resolve_bool "$RESTORE_BROKERS"; then
+    RESTORE_BROKERS=1
+  elif [ "$?" -eq 1 ]; then
+    RESTORE_BROKERS=0
+  else
+    die "MESHCORE_CA_RESTORE_BROKERS must be true/false, yes/no, on/off, or ask."
+  fi
+}
+
+choose_repeat_mode() {
+  if [ "$REPEAT_MODE" = "ask" ]; then
+    if prompt_yes_no "Should this device repeat packets for the local mesh?" "y"; then
+      REPEAT_MODE=on
+    else
+      REPEAT_MODE=off
+    fi
+  fi
+  case "$(printf '%s' "$REPEAT_MODE" | tr '[:upper:]' '[:lower:]')" in
+    on|repeat|repeater|1|true|yes|y) REPEAT_MODE=on ;;
+    off|observe-only|observer|0|false|no|n) REPEAT_MODE=off ;;
+    *) die "Repeat mode must be on or off." ;;
+  esac
+}
+
+list_serial_ports() {
+  local port found=0
+  for port in /dev/ttyUSB* /dev/ttyACM* /dev/cu.usbserial* /dev/cu.usbmodem* /dev/cu.SLAB_USBtoUART* /dev/cu.wchusbserial*; do
+    [ -e "$port" ] || continue
+    printf '%s\n' "$port"
+    found=1
+  done
+  [ "$found" -eq 1 ]
+}
+
+choose_serial_port() {
+  local ports count choice selected
+  if [ "$PRINT_ONLY" -eq 1 ]; then
+    return 0
+  fi
+  if [ -n "$SERIAL_PORT" ]; then
+    [ -e "$SERIAL_PORT" ] || die "Serial port not found: $SERIAL_PORT"
+    return 0
+  fi
+  ports="$(list_serial_ports || true)"
+  if [ -z "$ports" ]; then
+    say "No USB serial port was auto-detected."
+    say "Use --print-only to copy commands into the web/admin CLI, or rerun with --port PATH."
+    if prompt_yes_no "Print commands instead of sending over serial?" "y"; then
+      PRINT_ONLY=1
+      return 0
+    fi
+    SERIAL_PORT="$(prompt_text "Serial port path")"
+    [ -e "$SERIAL_PORT" ] || die "Serial port not found: $SERIAL_PORT"
+    return 0
+  fi
+
+  count="$(printf '%s\n' "$ports" | sed '/^$/d' | wc -l | tr -d ' ')"
+  if [ "$count" = "1" ]; then
+    selected="$(printf '%s\n' "$ports" | sed -n '1p')"
+    if prompt_yes_no "Use detected serial port $selected?" "y"; then
+      SERIAL_PORT="$selected"
+      return 0
+    fi
+  else
+    say "Detected serial ports:"
+    printf '%s\n' "$ports" | awk '{ n++; printf "  %d) %s\n", n, $0 }'
+  fi
+
+  while :; do
+    choice="$(prompt_text "Serial port number, path, or 'print'")"
+    case "$(printf '%s' "$choice" | tr '[:upper:]' '[:lower:]')" in
+      print|p)
+        PRINT_ONLY=1
+        return 0
+        ;;
+    esac
+    if printf '%s' "$choice" | grep -Eq '^[0-9]+$'; then
+      selected="$(printf '%s\n' "$ports" | sed -n "${choice}p")"
+      if [ -n "$selected" ]; then
+        SERIAL_PORT="$selected"
+        return 0
+      fi
+      echo "No serial port item number: $choice" >&2
+      continue
+    fi
+    SERIAL_PORT="$choice"
+    [ -e "$SERIAL_PORT" ] || die "Serial port not found: $SERIAL_PORT"
+    return 0
+  done
+}
+
+COMMANDS=()
+
+add_command() {
+  COMMANDS+=("$1")
+}
+
+build_commands() {
+  COMMANDS=()
+  add_command "set name $NODE_NAME"
+  if resolve_bool "$SET_RADIO"; then
+    add_command "set radio 910.525,62.5,7,5"
+  elif [ "$?" -eq 2 ]; then
+    die "MESHCORE_CA_SET_RADIO must be true/false, yes/no, or on/off."
+  fi
+  add_command "set path.hash.mode 2"
+  add_command "set mqtt.iata $IATA"
+  add_command "set wifi.ssid $WIFI_SSID"
+  add_command "set wifi.pwd $WIFI_PASSWORD"
+  add_command "set wifi.powersave none"
+  add_command "set mqtt.status on"
+  add_command "set mqtt.packets on"
+  add_command "set bridge.enabled on"
+  add_command "set mqtt.rx on"
+  add_command "set mqtt.tx advert"
+
+  if [ "$RESTORE_BROKERS" -eq 1 ]; then
+    add_command "set mqtt1.preset none"
+    add_command "set mqtt2.preset none"
+    add_command "set mqtt3.preset none"
+    add_command "set mqtt4.preset none"
+    add_command "set mqtt5.preset none"
+    add_command "set mqtt6.preset none"
+    add_command "set mqtt1.preset custom"
+    add_command "set mqtt1.server wss://$BROKER1_HOST:443"
+    add_command "set mqtt1.port 443"
+    add_command "set mqtt1.audience $BROKER1_HOST"
+    add_command "set mqtt2.preset custom"
+    add_command "set mqtt2.server wss://$BROKER2_HOST:443"
+    add_command "set mqtt2.port 443"
+    add_command "set mqtt2.audience $BROKER2_HOST"
+  fi
+
+  if [ "$REPEAT_MODE" = "off" ]; then
+    add_command "set repeat off"
+  fi
+  add_command "reboot"
+}
+
+print_commands() {
+  local mask_password="${1:-0}"
+  local cmd
+  printf '```text\n'
+  for cmd in "${COMMANDS[@]}"; do
+    if [ "$mask_password" -eq 1 ] && printf '%s' "$cmd" | grep -q '^set wifi.pwd '; then
+      printf 'set wifi.pwd ********\n'
+    else
+      printf '%s\n' "$cmd"
+    fi
+  done
+  printf '```\n'
+}
+
+configure_serial() {
+  if stty -F "$SERIAL_PORT" "$BAUD" raw -echo -echoe -echok -echoctl -echoke 2>/dev/null; then
+    return 0
+  fi
+  if stty -f "$SERIAL_PORT" "$BAUD" raw -echo -echoe -echok 2>/dev/null; then
+    return 0
+  fi
+  die "Could not configure serial port $SERIAL_PORT at $BAUD baud."
+}
+
+send_commands() {
+  local cmd
+  configure_serial
+  say "Sending setup commands to $SERIAL_PORT at $BAUD baud."
+  exec 3>"$SERIAL_PORT"
+  for cmd in "${COMMANDS[@]}"; do
+    if printf '%s' "$cmd" | grep -q '^set wifi.pwd '; then
+      say "Sending: set wifi.pwd ********"
+    else
+      say "Sending: $cmd"
+    fi
+    printf '%s\r\n' "$cmd" >&3
+    sleep "$COMMAND_DELAY"
+  done
+  exec 3>&-
+  say "Commands sent. The device should reboot."
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --board) BOARD="${2:?Missing value for --board}"; shift 2 ;;
+    --role) ROLE="${2:?Missing value for --role}"; shift 2 ;;
+    --iata) IATA="${2:?Missing value for --iata}"; shift 2 ;;
+    --name) NODE_NAME="${2:?Missing value for --name}"; shift 2 ;;
+    --wifi-ssid) WIFI_SSID="${2:?Missing value for --wifi-ssid}"; shift 2 ;;
+    --wifi-password) WIFI_PASSWORD="${2:?Missing value for --wifi-password}"; shift 2 ;;
+    --port) SERIAL_PORT="${2:?Missing value for --port}"; shift 2 ;;
+    --baud) BAUD="${2:?Missing value for --baud}"; shift 2 ;;
+    --delay) COMMAND_DELAY="${2:?Missing value for --delay}"; shift 2 ;;
+    --print-only) PRINT_ONLY=1; shift ;;
+    --restore-brokers) RESTORE_BROKERS=1; shift ;;
+    --no-restore-brokers) RESTORE_BROKERS=0; shift ;;
+    --set-radio) SET_RADIO=1; shift ;;
+    --no-set-radio) SET_RADIO=0; shift ;;
+    --repeat) REPEAT_MODE=on; shift ;;
+    --observe-only) REPEAT_MODE=off; shift ;;
+    --list-iata|--iata-list) print_iata_choices; exit 0 ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+choose_board
+choose_role
+require_iata
+choose_name
+require_wifi
+choose_restore_brokers
+choose_repeat_mode
+choose_serial_port
+build_commands
+
+printf '\n'
+say "Setup summary:"
+say "Board: $BOARD"
+say "Role: $ROLE"
+say "Name: $NODE_NAME"
+say "IATA: $IATA"
+say "WiFi SSID: $WIFI_SSID"
+say "Restore brokers: $RESTORE_BROKERS"
+say "Repeat packets: $REPEAT_MODE"
+if [ "$PRINT_ONLY" -eq 1 ]; then
+  say "Mode: print commands only"
+  printf '\nCopy/paste these commands into the MeshCore admin CLI:\n\n'
+  print_commands 0
+else
+  say "Serial port: $SERIAL_PORT"
+  printf '\nCommands to be sent:\n\n'
+  print_commands 1
+  printf '\n'
+  if prompt_yes_no "Send these commands to $SERIAL_PORT now?" "y"; then
+    send_commands
+  else
+    say "Canceled before sending. Re-run with --print-only to copy commands manually."
+    exit 1
+  fi
+fi
+
+say "Done. After reboot, check https://live.meshcore.ca/#/observers for $NODE_NAME."

--- a/docs/analyzer/troubleshooting.md
+++ b/docs/analyzer/troubleshooting.md
@@ -73,6 +73,7 @@ If your code is not on the quick list, that does not automatically mean it is un
 | MCtoMQTT | `/etc/mctomqtt/config.d/20-meshcore-ca.toml` |
 | Companion capture | `PACKETCAPTURE_IATA` in `~/.meshcore-packet-capture/.env.local` |
 | Home Assistant | MeshCore integration region/IATA field |
+| RemoteTerm | Community MQTT region/IATA field |
 
 ## PyMC
 
@@ -96,6 +97,22 @@ If a code such as `YTR` is missing from a picker, update the MeshCore Home Assis
 | Cannot enter a real IATA code | Update MeshCore-HA; current versions use free text |
 | Backup broker fails | `Token Audience` must match the broker host (`mqtt2.meshcore.ca`) |
 | Observer appears under the wrong city | Both broker entries use the same nearest real IATA code |
+
+## RemoteTerm
+
+Open **Settings** -> **MQTT & Automation** and confirm each Community MQTT entry:
+
+| Field | Expected value |
+|-------|----------------|
+| Broker Host | `mqtt1.meshcore.ca` or `mqtt2.meshcore.ca` |
+| Broker Port | `443` |
+| Transport | `WebSockets` |
+| Authentication | `Token` |
+| TLS | Enabled and verified |
+| Region Code | Your nearest real IATA code |
+| Packet Topic Template | `meshcore/{IATA}/{PUBLIC_KEY}/packets` |
+
+If the primary entry works and the backup does not, check the second entry's token audience. It must be `mqtt2.meshcore.ca`.
 
 ## Still Not Working?
 

--- a/docs/analyzer/verify.md
+++ b/docs/analyzer/verify.md
@@ -1,6 +1,6 @@
 # Check Your Observer
 
-After setting up your observer using any of the four paths ([MQTT Firmware](builds/mqtt-firmware.md), [MCtoMQTT](builds/mctomqtt.md), [PyMC](builds/pymc.md), or [Home Assistant](builds/meshcore-ha.md)), use the links below to confirm it's online and reporting.
+After setting up your observer using any supported path ([MQTT Firmware](builds/mqtt-firmware.md), [MCtoMQTT](builds/mctomqtt.md), [PyMC](builds/pymc.md), [Home Assistant](builds/meshcore-ha.md), or [RemoteTerm](remoteterm.md)), use the links below to confirm it's online and reporting.
 
 <div class="grid cards" markdown>
 
@@ -39,6 +39,16 @@ After setting up your observer using any of the four paths ([MQTT Firmware](buil
 </div>
 
 Your observer should appear within a few minutes of coming online.
+
+## Healthy Observer Checklist
+
+| Check | Expected result |
+|-------|-----------------|
+| Observer name | Clear node name such as `YOW-Repeater-01` |
+| Region | Nearest real IATA code, not `CAN`, `XXX`, or `HOME` |
+| Broker coverage | Primary and backup broker configured where the path supports both |
+| Packet activity | Recent packet timestamps on CoreScope after nearby mesh activity |
+| Radio settings | `USA/Canada (Recommended)` and 3-byte path hashes unless your local page differs |
 
 ## First Checks
 

--- a/docs/meshcore/antennas.md
+++ b/docs/meshcore/antennas.md
@@ -1,28 +1,48 @@
 # Recommended Antennas
 
-!!! info "This page is a work in progress"
-    Content coming soon. Want to help? See [Contributing](../contributing.md).
+Antenna choice and placement usually affect MeshCore range more than the exact board model. Start with a known-good 915 MHz antenna, mount it cleanly, and test before chasing firmware changes.
 
 ## Antenna Basics
 
-<!-- TODO: Quick primer on antenna types, gain, and why antenna choice matters for LoRa -->
+| Concept | Practical meaning |
+|---------|-------------------|
+| Frequency match | Use antennas intended for the Canadian/US 902-928 MHz band |
+| Gain | Higher gain can help in the right direction, but may reduce coverage above and below the antenna |
+| Placement | Height and line of sight often matter more than advertised gain |
+| Feedline loss | Long or poor coax can waste the antenna improvement |
+| Connector quality | Loose adapters and mismatched connectors cause hard-to-debug range issues |
 
-## Recommended Antennas
-
-<!-- TODO: Table of recommended antennas for different use cases -->
-
-| Antenna | Type | Gain | Frequency | Best For | Notes |
-|---------|------|------|-----------|----------|-------|
-| <!-- TODO --> | | | | | |
+!!! warning "Check local rules"
+    You are responsible for legal operation, including power, antenna gain, and duty cycle limits that apply to your station and location.
 
 ## Companion Antennas
 
-<!-- TODO: Portable/handheld antenna recommendations -->
+| Use case | Good fit | Notes |
+|----------|----------|-------|
+| Pocket node | Short 915 MHz whip | Convenient, but range is limited indoors |
+| Portable testing | Longer flexible whip | Better than tiny stock antennas for field checks |
+| Desk or window | Small magnetic/base antenna | Move it away from USB hubs, laptops, and metal blinds |
+
+If a companion seems deaf, test with a second known-good antenna before reflashing.
 
 ## Repeater / Base Antennas
 
-<!-- TODO: Fixed-mount antenna recommendations, collinear, yagi, etc. -->
+| Use case | Good fit | Notes |
+|----------|----------|-------|
+| Local neighborhood | Outdoor vertical | Simple, broad coverage pattern |
+| Valley or corridor | Directional antenna | Useful when coverage is needed mostly one way |
+| Rooftop reference node | Outdoor vertical plus short feedline | Keep cable loss low and weatherproof connectors |
 
-## DIY Antenna Builds
+Outdoor repeaters should be tested at ground level first, then tested again after final mounting. Record the antenna and cable used in the deployment notes.
 
-<!-- TODO: Links or guides for building your own antennas -->
+## Installation Tips
+
+- Keep the antenna clear of metal siding, gutters, and solar panel frames.
+- Do not rely on a connector adapter stack outdoors.
+- Weatherproof outdoor coax connections.
+- Avoid sharp coax bends and strain at the board connector.
+- Re-check range after heavy rain, snow, or enclosure changes.
+
+## DIY Antennas
+
+DIY antennas can work well, but they should be measured or compared against a known-good antenna. A visually neat antenna can still be off-frequency. For shared community repeaters, prefer tested commercial antennas unless someone can validate the build.

--- a/docs/meshcore/companions.md
+++ b/docs/meshcore/companions.md
@@ -1,11 +1,6 @@
 # Recommended Companions
 
-!!! info "This page is a work in progress"
-    Content coming soon. Want to help? See [Contributing](../contributing.md).
-
-## What is a Companion Device?
-
-A companion is the device you carry or keep nearby to send and receive MeshCore messages. It still needs the same network settings as the repeaters around it.
+A companion is the device you carry or keep nearby to send and receive MeshCore messages. It pairs with a phone, tablet, desktop app, web app, or serial client depending on the firmware and hardware.
 
 ## MeshCore Canada Settings
 
@@ -17,7 +12,7 @@ Use these settings before testing range or message delivery:
 | Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
 | Path hash mode | `3-byte` |
 
-If your companion app exposes a **Path hash mode**, **Path hash size**, or **Advert path** option, set it to **3-byte**. This is the recommended MeshCore Canada setting for companion radios on repeater-backed networks.
+If your companion app exposes a **Path hash mode**, **Path hash size**, or **Advert path** option, set it to **3-byte**.
 
 If your companion is configured through a MeshCore CLI that supports the setting, use:
 
@@ -28,14 +23,37 @@ set path.hash.mode 2
 !!! warning "Common onboarding miss"
     A companion can be flashed successfully and still be off-network if it is left on another regional preset or a 1-byte path setting. Set **USA/Canada (Recommended)** first, then set the path mode to **3-byte**.
 
-## Recommended Devices
+## Choosing a Companion
 
-<!-- TODO: Table of recommended companion devices with specs, price range, pros/cons -->
+| Priority | What to look for |
+|----------|------------------|
+| Official support | The board appears in the MeshCore Flasher or official MeshCore hardware list |
+| Radio match | LoRa radio variant supports the Canadian band used by your community |
+| Usability | BLE, USB, or WiFi connection method works with the app you plan to use |
+| Power | Battery capacity and charging are appropriate for portable use |
+| Recovery | You can access USB serial or boot mode if a flash or config change goes wrong |
 
-| Device | Chipset | Display | Battery | Notes |
-|--------|---------|---------|---------|-------|
-| <!-- TODO --> | | | | |
+Avoid buying hardware only because it works with another LoRa mesh project. Confirm MeshCore support first.
 
-## Firmware Flashing
+## Good First-Device Patterns
 
-<!-- TODO: Links to firmware and flashing instructions for each device -->
+| Pattern | Best for | Notes |
+|---------|----------|-------|
+| Ready-made companion node | New users | Least assembly, easiest support path |
+| ESP32 LoRa board with display | Tinkerers | Useful for serial recovery and status, but check exact board revision |
+| Small battery-powered node | Portable use | Prioritize antenna quality and app support over tiny size |
+| Spare repeater-capable board | Testing | Can be reflashed later as a repeater or observer if WiFi is supported |
+
+## First Setup Checklist
+
+1. Flash a MeshCore companion firmware supported by your board.
+2. Pair or connect from your chosen MeshCore app.
+3. Set the radio preset to **USA/Canada (Recommended)**.
+4. Set path hash mode to **3-byte**.
+5. Reboot after changing radio parameters.
+6. Send an advert.
+7. Ask a nearby community member to confirm they can see you.
+
+## When a Companion Should Not Be the Observer
+
+A companion can report packets through some host-side tools, but a fixed observer is usually better when you want reliable live telemetry. If your goal is to feed CoreScope continuously, use the [Analyzer & MQTT](../analyzer/intro.md) observer guides.

--- a/docs/meshcore/faq.md
+++ b/docs/meshcore/faq.md
@@ -1,11 +1,6 @@
 # MeshCore FAQ
 
-!!! info "This page is a work in progress"
-    Content coming soon. Want to help? See [Contributing](../contributing.md).
-
 ## General
-
-<!-- TODO: Common questions about MeshCore -->
 
 ??? question "What frequencies does MeshCore use in Canada?"
     MeshCore Canada communities should start with the **USA/Canada (Recommended)** preset.
@@ -21,34 +16,48 @@
 
     Always check your local province or community page in case a nearby mesh publishes a different setting.
 
-??? question "Do I need a ham radio license?"
-    <!-- TODO: License requirements for different power levels -->
+??? question "What is 3-byte path hash mode?"
+    MeshCore adverts include compact path identifiers. MeshCore Canada recommends **3-byte** path hashes because larger repeater-backed networks have more room for unique identifiers than with the legacy 1-byte setting.
 
-??? question "What is the range I can expect?"
-    <!-- TODO: Typical ranges, factors that affect range -->
-
-## Hardware
-
-<!-- TODO: Hardware-related questions -->
-
-??? question "What devices are compatible with MeshCore?"
-    <!-- TODO: List of supported boards -->
-
-??? question "Can I use my Meshtastic device with MeshCore?"
-    <!-- TODO: Compatibility info -->
-
-## Network
-
-<!-- TODO: Network and mesh questions -->
-
-??? question "How do I join an existing mesh network?"
-    Set your radio preset to **USA/Canada (Recommended)**, then set path hash mode to **3-byte**. Companions, repeaters, room servers, and observers all need compatible radio settings before they can hear each other.
-
-    On devices with MeshCore CLI access, the 3-byte setting is:
+    In the MeshCore CLI, use:
 
     ```text
     set path.hash.mode 2
     ```
+
+??? question "Do I need a ham radio license?"
+    MeshCore Canada cannot give legal advice. Most Canadian MeshCore community docs assume licence-exempt LoRa operation in the appropriate ISM band, but you are responsible for using legal frequencies, power levels, antennas, and duty cycle in your location.
+
+    If you are operating as an amateur radio station or using non-standard equipment, check the current ISED rules and local amateur radio guidance before transmitting.
+
+??? question "What range should I expect?"
+    Range depends heavily on antenna quality, height, terrain, obstructions, noise floor, and line of sight. A handheld device indoors may only cover a neighborhood. A well-placed outdoor repeater with a clear antenna view can cover much more.
+
+    For troubleshooting, compare against a nearby known-good node before assuming the firmware or MQTT path is broken.
+
+## Hardware
+
+??? question "What devices are compatible with MeshCore?"
+    Use devices listed by the MeshCore Flasher or by a MeshCore Canada build guide for the role you need. Compatibility varies by radio chip, flash size, board wiring, display, battery hardware, and WiFi support.
+
+    The MeshCore.ca direct MQTT firmware path currently targets WiFi-capable LoRa boards published in the [MQTT Firmware](../analyzer/builds/mqtt-firmware.md) guide.
+
+??? question "Can I use my Meshtastic device with MeshCore?"
+    Sometimes, but it must be flashed with MeshCore firmware and supported by the MeshCore build you choose. A device running Meshtastic firmware will not join a MeshCore mesh.
+
+    Back up any identity or configuration you care about before reflashing. Treat a first MeshCore flash as a new setup.
+
+??? question "Which board should I buy first?"
+    For a first companion, choose a board or ready-made device that is listed in the official MeshCore tools and has community support near you. For a fixed repeater or observer, prioritize stable power, a good antenna path, and remote access over display features.
+
+## Network
+
+??? question "How do I join an existing mesh network?"
+    1. Find your local page in the [Mesh Directory](../provinces/index.md).
+    2. Set the radio preset to **USA/Canada (Recommended)** unless the local page says otherwise.
+    3. Set path hash mode to **3-byte**.
+    4. Reboot the device after changing radio settings.
+    5. Send an advert and check whether nearby users can see you.
 
 ??? question "How do I set up a new mesh in my area?"
     Use the MeshCore Canada baseline unless you have a local reason to publish a different setting:
@@ -58,4 +67,9 @@
     set path.hash.mode 2
     ```
 
-    Publish the chosen settings clearly on your community page so new users know which preset to pick.
+    Then open an update request through [Contributing](../contributing.md) so the directory can list the community, region, status, contacts, and any setting differences.
+
+??? question "Why does my observer show no packets?"
+    A broker connection only proves the observer reached MQTT. It may still hear no mesh traffic if the radio preset is wrong, path hash mode is wrong, packet publishing is disabled, or no nearby nodes are active.
+
+    Use [Check Your Observer](../analyzer/verify.md) and [Troubleshooting](../analyzer/troubleshooting.md) to narrow the symptom.

--- a/docs/meshcore/intro.md
+++ b/docs/meshcore/intro.md
@@ -1,16 +1,46 @@
 # Introduction to MeshCore
 
-!!! info "This page is a work in progress"
-    Content coming soon. Want to help? See [Contributing](../contributing.md).
+MeshCore is a lightweight mesh radio system for LoRa devices. A MeshCore network lets nearby radios pass messages and routing information between each other without relying on cellular service, WiFi, or the public internet.
 
-## What is MeshCore?
+MeshCore Canada documents the settings and community conventions Canadian meshes use so new devices can join the right network quickly.
 
-<!-- TODO: Explain MeshCore protocol, how it differs from Meshtastic, LoRa basics -->
+## Core Ideas
 
-## How Does It Work?
+| Term | Meaning |
+|------|---------|
+| Companion | A personal radio paired with a phone, tablet, or computer for sending and receiving messages |
+| Repeater | A fixed radio that relays traffic to extend coverage |
+| Room server | A fixed node that hosts rooms and may also relay or observe mesh traffic |
+| Observer | A radio or host service that forwards packet telemetry to MeshCore.ca over MQTT |
 
-<!-- TODO: High-level overview of companions, repeaters, and room servers -->
+All devices in the same local mesh must agree on the radio settings. If a device is flashed correctly but uses a different preset, it may look healthy while hearing nothing nearby.
 
-## Why MeshCore?
+## MeshCore Canada Baseline
 
-<!-- TODO: Benefits, use cases, off-grid communication scenarios -->
+Use these defaults unless your local community page publishes a different setting:
+
+| Setting | Value |
+|---------|-------|
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| CLI path setting | `set path.hash.mode 2` |
+
+!!! tip "Start with Getting Started"
+    If you are setting up a first device, use [Getting Started](../resources/getting-started.md) before choosing a hardware-specific guide.
+
+## How Traffic Moves
+
+Companions send messages into the mesh. Repeaters and room servers help carry those packets beyond the range of a single radio link. Observers listen to the same mesh traffic and publish packet metadata to the MeshCore.ca MQTT brokers for live tools such as CoreScope.
+
+MeshCore traffic is still radio-first. MQTT does not replace the local mesh; it gives communities visibility into observers, packet flow, and regional health.
+
+## Why These Settings Matter
+
+MeshCore Canada uses a shared baseline to make roaming and inter-community support easier:
+
+- New users can ask for help without first translating local radio parameters.
+- Repeaters, room servers, and observers can be tested with the same checklist.
+- Community pages only need to document exceptions when a local mesh intentionally differs.
+
+Before judging range or troubleshooting MQTT, confirm the radio preset and path hash mode first.

--- a/docs/meshcore/repeater-builds.md
+++ b/docs/meshcore/repeater-builds.md
@@ -1,11 +1,8 @@
 # Repeater Build Guides
 
-!!! info "This page is a work in progress"
-    Content coming soon. Want to help? See [Contributing](../contributing.md).
+This page gives practical build patterns for MeshCore Canada repeaters. Use the hardware-specific firmware guide when you are ready to flash a board.
 
-## Overview
-
-Step-by-step guides for building and deploying MeshCore repeaters.
+## Baseline Configuration
 
 Before placing a repeater, configure it for the MeshCore Canada network:
 
@@ -27,12 +24,68 @@ reboot
 
 ## Indoor Repeater
 
-<!-- TODO: Parts list, assembly, firmware flash, configuration -->
+Use this pattern for testing, apartments, windowsill coverage, or a known-good spare node.
 
-## Outdoor / Weatherproof Repeater
+| Part | Recommendation |
+|------|----------------|
+| Board | MeshCore-supported LoRa board |
+| Power | Stable USB power supply |
+| Antenna | Short 915 MHz antenna, away from computer noise |
+| Location | Window or high shelf, not behind metal or appliances |
 
-<!-- TODO: Enclosure options, weatherproofing, mounting -->
+Checklist:
+
+1. Flash firmware and configure radio/path settings.
+2. Set a clear node name such as `YOW-Indoor-Repeater-01`.
+3. Reboot and send an advert.
+4. Confirm a companion can hear it from another room or outside.
+5. Leave it running for a day before using it as a reference node.
+
+## Outdoor Repeater
+
+Use this pattern for roof, mast, or tower deployments.
+
+| Part | Recommendation |
+|------|----------------|
+| Enclosure | Weatherproof, UV-resistant, with strain relief |
+| Power | Protected USB, PoE splitter, or DC regulator with margin |
+| Antenna | Outdoor 915 MHz antenna mounted above obstructions |
+| Cable | Short coax run or low-loss feedline |
+| Service access | USB or serial access without fully rebuilding the site |
+
+Before mounting, confirm:
+
+- The repeater hears at least one known local node.
+- The node name and community page identify the region.
+- The path hash mode is 3-byte.
+- The enclosure is sealed but not trapping condensation against the board.
 
 ## Solar-Powered Remote Repeater
 
-<!-- TODO: Solar panel sizing, battery, charge controller, full build walkthrough -->
+Remote sites need more margin than indoor tests.
+
+| Area | Check |
+|------|-------|
+| Battery | Sized for overnight load and several low-sun days |
+| Panel | Sized for winter sun angle and snow/dirt losses |
+| Charge controller | Suitable for the battery chemistry |
+| Enclosure | Venting or moisture control considered |
+| Monitoring | Physical access plan and last-known config recorded |
+
+For direct MQTT observers, also confirm WiFi or backhaul at the final installation point. A good radio site can still be a poor observer site if internet access is unreliable.
+
+## Deployment Record
+
+Keep a short record for every fixed repeater:
+
+| Field | Example |
+|-------|---------|
+| Node name | `YOW-Repeater-01` |
+| Region/IATA | `YOW` |
+| Firmware | `20260521` |
+| Radio preset | `USA/Canada (Recommended)` |
+| Path hash mode | `3-byte` |
+| Antenna | Outdoor 915 MHz vertical |
+| Contact | Community page, Discord, Telegram, or maintainer |
+
+This makes community support much easier when a repeater disappears or starts reporting under the wrong region.

--- a/docs/meshcore/repeaters.md
+++ b/docs/meshcore/repeaters.md
@@ -1,10 +1,5 @@
 # Recommended Repeaters
 
-!!! info "This page is a work in progress"
-    Content coming soon. Want to help? See [Contributing](../contributing.md).
-
-## What is a Repeater?
-
 A repeater extends local mesh coverage by hearing packets and forwarding them for other nodes. It must use the same radio preset and path hash settings as the surrounding MeshCore Canada network.
 
 ## Required Network Settings
@@ -25,18 +20,40 @@ reboot
 !!! warning "Check before installation"
     A repeater installed with the wrong regional preset or path hash mode can look healthy locally but still fail to participate in the MeshCore Canada network. Fresh 2026-05-21 and newer MeshCore.ca direct MQTT firmware already defaults to the USA/Canada radio preset, but older images, retained preferences, and generic firmware should be verified with `set radio 910.525,62.5,7,5` before mounting the device somewhere hard to reach.
 
-## Recommended Devices
+## Hardware Selection
 
-<!-- TODO: Table of recommended repeater hardware -->
+| Priority | Why it matters |
+|----------|----------------|
+| Stable power | Brownouts cause confusing mesh and MQTT failures |
+| Outdoor-rated enclosure | Moisture and condensation are common failure modes |
+| Accessible USB or serial | Remote sites are hard to recover after a bad config |
+| Quality antenna and feedline | Antenna placement usually matters more than board choice |
+| WiFi support | Required for direct MQTT observer firmware |
 
-| Device | Chipset | Power Source | Enclosure | Notes |
-|--------|---------|-------------|-----------|-------|
-| <!-- TODO --> | | | | |
+## Known Direct MQTT Repeater Targets
 
-## Solar-Powered Setups
+The [MQTT Firmware](../analyzer/builds/mqtt-firmware.md) guide publishes repeater and room-server builds for WiFi-capable LoRa boards.
 
-<!-- TODO: Info on solar repeater builds for remote deployment -->
+| Board | Status | Notes |
+|-------|--------|-------|
+| Heltec V3 | Field-tested | Good first direct MQTT target |
+| Heltec V4 OLED | Build verified | Smoke test before remote install |
+| LILYGO T3S3 SX1262 | Build verified | Smoke test before remote install |
+| LILYGO T-Beam S3 Supreme SX1262 | Build verified | PSRAM target profile |
+| LILYGO T-Beam SX1262 | Build verified | Smoke test before remote install |
+| Seeed XIAO ESP32S3 + Wio-SX1262 | Build verified | Compact build target |
+
+!!! note "RAK3112 direct firmware"
+    RAK3112 is not part of the direct WiFi MQTT firmware path because that path requires onboard WiFi.
 
 ## Placement Tips
 
-<!-- TODO: Antenna height, line of sight, optimal locations -->
+- Put the antenna high enough to clear nearby roofs, terrain, and dense trees where possible.
+- Keep coax runs short, or use lower-loss feedline for longer runs.
+- Keep the radio and power path serviceable after installation.
+- Test from the ground before installing on a roof, mast, or remote site.
+- Record the node name, IATA code, firmware date, and config commands used.
+
+## Solar-Powered Repeaters
+
+For solar sites, size the battery and panel for the worst expected weather, not the best day of the year. Leave enough margin for cold temperatures, snow cover, and consecutive cloudy days. If the site also acts as an MQTT observer, confirm WiFi or backhaul stability before assuming radio range is the issue.

--- a/docs/provinces/alberta.md
+++ b/docs/provinces/alberta.md
@@ -2,69 +2,61 @@
 
 This page lists MeshCore communities in Alberta.
 
-If you know of a community that is missing or needs an update, please open a pull request.  
-See [Contributing](../contributing.md) for how to add or update entries.
+If you know of a community that is missing or needs an update, open an update request through [Contributing](../contributing.md).
 
 ## Communities
 
-**Name:** Calgary and Area MeshCore
+### Calgary and Area MeshCore
 
-**Region:** Calgary and area
+| Field | Value |
+|-------|-------|
+| Region | Calgary and area |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Telegram | Calgary topic in [Mesh Alberta](https://t.me/meshtAlta) |
+| Discord | Canada - Calgary, Alberta & Area regional channel in the MeshCore Discord |
 
-**Status:** Active
+### YQLMesh
 
-**Frequency:** USA/Canada (Recommended) (910.525 MHz / 62.5 kHz / 7 / 5)
+| Field | Value |
+|-------|-------|
+| Region | Lethbridge |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Website | <https://www.yqlmesh.com> |
+| Facebook | [YQLMesh Community](https://www.facebook.com/groups/839542635605360) |
+| Discord | <https://discord.gg/89DUBvmvu2> |
 
-**Telegram** Calgary topic in [Mesh Alberta](https://t.me/meshtAlta)
+### Southern Alberta
 
-**Discord:** [Canada — Calgary, Alberta & Area - CYYC 🇨🇦](https://discord.com/channels/1343693475589263471/1443051476707442778) regional channel in MeshCore discord
+| Field | Value |
+|-------|-------|
+| Region | Southern Alberta, including Cardston, Magrath, Raymond, and nearby areas |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Discord | Canada - Southern Alberta regional channel in the MeshCore Discord |
+| Telegram | Cardston topic in [Mesh Alberta](https://t.me/meshtAlta) |
 
----
+### YYC MeshCore Discord Group
 
-**Name:** YQLMesh
+| Field | Value |
+|-------|-------|
+| Region | Calgary |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Discord | <https://discord.gg/CznDhsRWnJ> |
+| Website | <https://meshmonitoring.com/> |
 
-**Region:** Lethbridge
+## Province-Wide Contacts
 
-**Status:** Active
-
-**Frequency:** USA/Canada (Recommended) (910.525 MHz / 62.5 kHz / 7 / 5)
-
-**Website:** [https://www.yqlmesh.com](https://www.yqlmesh.com)
-
-**Facebook:** [YQLMesh Community](https://www.facebook.com/groups/839542635605360)
-
-**Discord:** [YQLMesh](https://discord.gg/89DUBvmvu2)
-
----
-
-**Name:** Southern Alberta
-
-**Region:** Southern Alberta (Cardston, Magrath, and Raymond, and beyond)
-
-**Status:** Active
-
-**Frequency:** USA/Canada (Recommended) (910.525 MHz / 62.5 kHz / 7 / 5)
-
-**Discord:** [Canada — Southern Alberta 🇨🇦](https://discord.com/channels/1343693475589263471/1404852676612849684) regional channel in MeshCore discord
-
-**Telegram:** Cardston topic in [Mesh Alberta](https://t.me/meshtAlta)
-
----
-
-**Name:** YYC (Calgary) Meshcore Discord Group
-
-**Region:** Calgary, Alberta, Canada
-
-**Status:** Active
-
-**Frequency:** USA/Canada (Recommended) (910.525 MHz / 62.5 kHz / 7 / 5)
-
-**Discord:** [https://discord.gg/CznDhsRWnJ](https://discord.gg/CznDhsRWnJ)
-
-**Website:** [https://meshmonitoring.com/](https://meshmonitoring.com/)
-
----
-
-# See also
-
-**Telegram:** Alberta topic in [MeshCore Canada](https://t.me/MeshCoreCAN)
+| Contact | Link |
+|---------|------|
+| Telegram | Alberta topic in [MeshCore Canada](https://t.me/MeshCoreCAN) |

--- a/docs/provinces/british-columbia.md
+++ b/docs/provinces/british-columbia.md
@@ -1,20 +1,18 @@
 # MeshCore Communities in British Columbia
 
-This page lists MeshCore communities in British Columbia.  
+This page lists MeshCore communities in British Columbia.
 
-If you know of a community that is missing or needs an update, please open a pull request.  
-See [Contributing](../contributing.md) for how to add or update entries.
+If you know of a community that is missing or needs an update, open an update request through [Contributing](../contributing.md).
 
 ## Communities
 
-**Name:** Salish Mesh
+### Salish Mesh
 
-**Region:** Salish Sea and surrounding area  
-
-**Status:** Active  
-
-**Frequency:** 910.525 MHz / 62.5 kHz / 7 / 5  
-
-**Website:** [https://salishmesh.net/](https://salishmesh.net/)
-
----
+| Field | Value |
+|-------|-------|
+| Region | Salish Sea and surrounding area |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Website | <https://salishmesh.net/> |

--- a/docs/provinces/index.md
+++ b/docs/provinces/index.md
@@ -5,19 +5,45 @@ Find the nearest MeshCore Canada community page for your province or territory. 
 !!! tip "Start local"
     MeshCore Canada generally uses the USA/Canada radio preset and 3-byte path hashes, but local pages are the source of truth when a community documents a different preset or operating practice.
 
+## National Baseline
+
+Use these defaults unless a local community page publishes a different setting:
+
+| Setting | Value |
+|---------|-------|
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| CLI path setting | `set path.hash.mode 2` |
+
 ## Provinces and Territories
 
-- [British Columbia](british-columbia.md)
-- [Alberta](alberta.md)
-- [Saskatchewan](saskatchewan.md)
-- [Manitoba](manitoba.md)
-- [Ontario](ontario.md)
-- [Quebec](quebec.md)
-- [New Brunswick](new-brunswick.md)
-- [Nova Scotia](nova-scotia.md)
-- [Prince Edward Island](prince-edward-island.md)
-- [Newfoundland and Labrador](newfoundland-and-labrador.md)
-- [Territories (YT / NT / NU)](territories.md)
+| Region | Directory status |
+|--------|------------------|
+| [British Columbia](british-columbia.md) | Active listing |
+| [Alberta](alberta.md) | Active listings |
+| [Saskatchewan](saskatchewan.md) | Needs community listing |
+| [Manitoba](manitoba.md) | Needs community listing |
+| [Ontario](ontario.md) | Active listings |
+| [Quebec](quebec.md) | Active listings |
+| [New Brunswick](new-brunswick.md) | Forming listing |
+| [Nova Scotia](nova-scotia.md) | Active listing |
+| [Prince Edward Island](prince-edward-island.md) | Needs community listing |
+| [Newfoundland and Labrador](newfoundland-and-labrador.md) | Needs community listing |
+| [Territories (YT / NT / NU)](territories.md) | Needs community listing |
+
+## Community Entry Format
+
+Community pages should use the same basic fields so newcomers can scan quickly:
+
+| Field | What to include |
+|-------|-----------------|
+| Name | Community or mesh name |
+| Region | City, area, province, or coverage region |
+| Status | Active, forming, testing, or needs update |
+| Radio settings | Preset plus raw values when known |
+| Path hash mode | Usually 3-byte for MeshCore Canada |
+| Contact | Discord, Telegram, website, issue link, or maintainer |
 
 ## Missing or outdated local information?
 

--- a/docs/provinces/manitoba.md
+++ b/docs/provinces/manitoba.md
@@ -1,10 +1,17 @@
 # MeshCore Communities in Manitoba
 
-This page lists MeshCore communities in Manitoba.  
+This page is ready for Manitoba MeshCore community listings.
 
-If you know of a community that is missing or needs an update, please open a pull request.  
-See [Contributing](../contributing.md) for how to add or update entries.
+## Current Status
 
-## Communities
+No Manitoba community listing has been submitted yet.
 
-WIP
+If you operate or know of a Manitoba MeshCore group, open an update request through [Contributing](../contributing.md) with the community name, region, status, contact link, and radio settings.
+
+## Default Settings
+
+| Setting | Value |
+|---------|-------|
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |

--- a/docs/provinces/new-brunswick.md
+++ b/docs/provinces/new-brunswick.md
@@ -1,20 +1,18 @@
 # MeshCore Communities in New Brunswick
 
-This page lists MeshCore communities in New Brunswick.  
+This page lists MeshCore communities in New Brunswick.
 
-If you know of a community that is missing or needs an update, please open a pull request.  
-See [Contributing](../contributing.md) for how to add or update entries.
+If you know of a community that is missing or needs an update, open an update request through [Contributing](../contributing.md).
 
 ## Communities
 
-**Name:** Southern New Brunswick  
+### Southern New Brunswick
 
-**Region:** Fredericton, Saint John, Moncton  
-
-**Status:** Forming  
-
-**Frequency:** 910.525 MHz / 62.5 kHz / 7 / 5  
-
-**Website:** [MESHCORE Saint John, N.B.](https://www.facebook.com/groups/613466831163684)
-
----
+| Field | Value |
+|-------|-------|
+| Region | Fredericton, Saint John, Moncton, and nearby areas |
+| Status | Forming |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Facebook | [MESHCORE Saint John, N.B.](https://www.facebook.com/groups/613466831163684) |

--- a/docs/provinces/newfoundland-and-labrador.md
+++ b/docs/provinces/newfoundland-and-labrador.md
@@ -1,10 +1,17 @@
 # MeshCore Communities in Newfoundland and Labrador
 
-This page lists MeshCore communities in Newfoundland and Labrador.  
+This page is ready for Newfoundland and Labrador MeshCore community listings.
 
-If you know of a community that is missing or needs an update, please open a pull request.  
-See [Contributing](../contributing.md) for how to add or update entries.
+## Current Status
 
-## Communities
+No Newfoundland and Labrador community listing has been submitted yet.
 
-WIP
+If you operate or know of a Newfoundland and Labrador MeshCore group, open an update request through [Contributing](../contributing.md) with the community name, region, status, contact link, and radio settings.
+
+## Default Settings
+
+| Setting | Value |
+|---------|-------|
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |

--- a/docs/provinces/nova-scotia.md
+++ b/docs/provinces/nova-scotia.md
@@ -1,20 +1,18 @@
 # MeshCore Communities in Nova Scotia
 
-This page lists MeshCore communities in Nova Scotia.  
+This page lists MeshCore communities in Nova Scotia.
 
-If you know of a community that is missing or needs an update, please open a pull request.  
-See [Contributing](../contributing.md) for how to add or update entries.
+If you know of a community that is missing or needs an update, open an update request through [Contributing](../contributing.md).
 
 ## Communities
 
-**Name:** Lunenburg County Mesh
+### Lunenburg County Mesh
 
-**Region:** Lunenburg County, Nova Scotia
-
-**Status:** Active
-
-**Frequency:** 910.525 MHz / 62.5 kHz / 7 / 5
-
-**Website:** [http://www.lunenburgcountymesh.ca](http://www.lunenburgcountymesh.ca)
-
----
+| Field | Value |
+|-------|-------|
+| Region | Lunenburg County |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Website | <http://www.lunenburgcountymesh.ca> |

--- a/docs/provinces/ontario.md
+++ b/docs/provinces/ontario.md
@@ -1,48 +1,42 @@
 # MeshCore Communities in Ontario
 
 This page lists MeshCore communities in Ontario.
-  
-If you know of a community that is missing or needs an update, please open a pull request.  
-See [Contributing](../contributing.md) for how to add or update entries.
+
+If you know of a community that is missing or needs an update, open an update request through [Contributing](../contributing.md).
 
 ## Communities
 
-**Name:** Greater Ottawa Mesh Enthusiasts  
+### Greater Ottawa Mesh Enthusiasts
 
-**Region:** Eastern Ontario & Western Quebec  
+| Field | Value |
+|-------|-------|
+| Region | Eastern Ontario and Western Quebec |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Discord | <https://discord.gg/WSyNd8SfNr> |
+| Website | <https://ottawamesh.ca/> |
 
-**Status:** Active  
+### GTA+-Lora-Meshes
 
-**Frequency:** 910.525 MHz / 62.5 kHz / 7 / 5  
+| Field | Value |
+|-------|-------|
+| Region | Southern Ontario |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Discord | <https://discord.gg/wSHbeb86r4> |
 
-**Discord:** [https://discord.gg/WSyNd8SfNr](https://discord.gg/WSyNd8SfNr)  
+### Quinte Mesh Network
 
-**Website:** [https://ottawamesh.ca](https://ottawamesh.ca/)
-
----
-
-**Name:** GTA+-Lora-Meshes
-
-**Region:** Southern Ontario
-
-**Status:** Active
-
-**Frequency:** 910.525 MHz / 62.5 kHz / 7 / 5
-
-**Discord:** [https://discord.gg/wSHbeb86r4](https://discord.gg/wSHbeb86r4)
-
----
-
-**Name:** Quinte Mesh Network
-
-**Region:** Quinte Region (Belleville, Trenton, Prince Edward County, and surrounding areas)
-
-**Status:** Active
-
-**Frequency:** 910.525 MHz / 62.5 kHz / 7 / 5
-
-**Discord:** [https://discord.gg/V5esJEP67X](hhttps://discord.gg/V5esJEP67X)
-
-**Website:** [https://quintemesh.ca](https://quintemesh.ca)
-
----
+| Field | Value |
+|-------|-------|
+| Region | Quinte Region, including Belleville, Trenton, Prince Edward County, and nearby areas |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Discord | <https://discord.gg/V5esJEP67X> |
+| Website | <https://quintemesh.ca/> |

--- a/docs/provinces/prince-edward-island.md
+++ b/docs/provinces/prince-edward-island.md
@@ -1,10 +1,17 @@
 # MeshCore Communities in Prince Edward Island
 
-This page lists MeshCore communities in Prince Edward Island.  
+This page is ready for Prince Edward Island MeshCore community listings.
 
-If you know of a community that is missing or needs an update, please open a pull request.  
-See [Contributing](../contributing.md) for how to add or update entries.
+## Current Status
 
-## Communities
+No Prince Edward Island community listing has been submitted yet.
 
-WIP
+If you operate or know of a Prince Edward Island MeshCore group, open an update request through [Contributing](../contributing.md) with the community name, region, status, contact link, and radio settings.
+
+## Default Settings
+
+| Setting | Value |
+|---------|-------|
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |

--- a/docs/provinces/quebec.md
+++ b/docs/provinces/quebec.md
@@ -1,52 +1,51 @@
 # MeshCore Communities in Quebec
 
-This page lists MeshCore communities in Quebec.  
+This page lists MeshCore communities in Quebec.
 
-If you know of a community that is missing or needs an update, please open a pull request.  
-See [Contributing](../contributing.md) for how to add or update entries.
+If you know of a community that is missing or needs an update, open an update request through [Contributing](../contributing.md).
 
 ## Communities
 
-**Name:** Mesh Quebec
+### Mesh Quebec
 
-**Region:** Québec
+| Field | Value |
+|-------|-------|
+| Region | Quebec |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Website | <https://qcmesh.net> |
 
-**Website:** [https://qcmesh.net ](hhttps://qcmesh.net) (currently redirects to the Telegram group)
+### Montreal Mesh
 
----
+| Field | Value |
+|-------|-------|
+| Region | Greater Montreal |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Website | <https://www.montrealmesh.ca> |
 
-**Name:** Montreal Mesh
+### Reseau Mesh de la Capitale YQB
 
-**Region:** Greater Montreal
+| Field | Value |
+|-------|-------|
+| Region | Quebec City |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Discord | <https://discord.com/channels/1497584274520412223> |
 
-**Status:** Active
+### Reseau Libre
 
-**Frequency:** 910.525 MHz / 62.5 kHz / 7 / 5
-
-**Discord:** [https://www.montrealmesh.ca](hhttps://www.montrealmesh.ca)
-
----
-
-**Name:** Réseau Mesh de la Capitale YQB
-
-**Region:** Québec
-
-**Status:** Active
-
-**Frequency:** 910.525 MHz / 62.5 kHz / 7 / 5
-
-**Discord:** [https://discord.com/channels/1497584274520412223](https://discord.com/channels/1497584274520412223)
-
----
-
-**Name:** Réseau Libre
-
-**Region:** Montreal
-
-**Status:** Active
-
-**Frequency:** 910.525 MHz / 62.5 kHz / 7 / 5
-
-**Discord:** [https://lora.reseaulibre.ca/](https://lora.reseaulibre.ca/)
-
----
+| Field | Value |
+|-------|-------|
+| Region | Montreal |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Website | <https://lora.reseaulibre.ca/> |

--- a/docs/provinces/quebec.md
+++ b/docs/provinces/quebec.md
@@ -28,7 +28,7 @@ If you know of a community that is missing or needs an update, open an update re
 | Path hash mode | `3-byte` |
 | Website | <https://www.montrealmesh.ca> |
 
-### Reseau Mesh de la Capitale YQB
+### Réseau Mesh de la Capitale YQB
 
 | Field | Value |
 |-------|-------|
@@ -39,7 +39,7 @@ If you know of a community that is missing or needs an update, open an update re
 | Path hash mode | `3-byte` |
 | Discord | <https://discord.com/channels/1497584274520412223> |
 
-### Reseau Libre
+### Réseau Libre
 
 | Field | Value |
 |-------|-------|

--- a/docs/provinces/saskatchewan.md
+++ b/docs/provinces/saskatchewan.md
@@ -1,10 +1,17 @@
 # MeshCore Communities in Saskatchewan
 
-This page lists MeshCore communities in Saskatchewan.  
+This page is ready for Saskatchewan MeshCore community listings.
 
-If you know of a community that is missing or needs an update, please open a pull request.  
-See [Contributing](../contributing.md) for how to add or update entries.
+## Current Status
 
-## Communities
+No Saskatchewan community listing has been submitted yet.
 
-WIP
+If you operate or know of a Saskatchewan MeshCore group, open an update request through [Contributing](../contributing.md) with the community name, region, status, contact link, and radio settings.
+
+## Default Settings
+
+| Setting | Value |
+|---------|-------|
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |

--- a/docs/provinces/territories.md
+++ b/docs/provinces/territories.md
@@ -1,10 +1,17 @@
-# MeshCore Communities in Territories
+# MeshCore Communities in the Territories
 
-This page lists MeshCore communities in Territories.  
+This page is ready for Yukon, Northwest Territories, and Nunavut MeshCore community listings.
 
-If you know of a community that is missing or needs an update, please open a pull request.  
-See [Contributing](../contributing.md) for how to add or update entries.
+## Current Status
 
-## Communities
+No territories community listing has been submitted yet.
 
-WIP
+If you operate or know of a MeshCore group in Yukon, Northwest Territories, or Nunavut, open an update request through [Contributing](../contributing.md) with the community name, region, status, contact link, and radio settings.
+
+## Default Settings
+
+| Setting | Value |
+|---------|-------|
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |

--- a/docs/resources/getting-started.md
+++ b/docs/resources/getting-started.md
@@ -33,6 +33,8 @@ Choose a role:
 - **Room server**: a fixed node that hosts rooms and can also observe mesh traffic.
 - **Observer**: a device or host service that forwards packets to the MeshCore.ca MQTT analyzer.
 
+Start with [Recommended Companions](../meshcore/companions.md) if you want a personal device, or [Recommended Repeaters](../meshcore/repeaters.md) if you are building a fixed node.
+
 ## Step 3: Flash the Firmware
 
 Flash firmware for the role you need, then apply the MeshCore Canada network settings before judging whether the device works.
@@ -53,13 +55,32 @@ set path.hash.mode 2
 
 After changing radio parameters, reboot the device.
 
-## Step 4: Find or Start a Community
+## Step 4: Configure Your Role
+
+| Role | Next setup step |
+|------|-----------------|
+| Companion | Pair it with your app, send an advert, and ask a nearby user to confirm they can see you |
+| Repeater | Pick a clear node name, test from the ground, then install it where it has good antenna visibility |
+| Room server | Configure rooms, verify it still uses the local mesh settings, and document who maintains it |
+| Observer | Follow [Analyzer & MQTT](../analyzer/intro.md) and verify it appears in CoreScope |
+
+## Step 5: Find or Start a Community
 
 Browse the [Mesh Directory](../provinces/index.md) and check your province or nearby region. If a local community documents a different preset, follow the local community setting for that mesh.
 
-## Step 5: Get on the Air
+If your region is missing, use [Contributing](../contributing.md) to request a new listing with the community name, region, status, contacts, and radio settings.
+
+## Step 6: Get on the Air
 
 Send an advert after configuration so nearby nodes learn your identity and route. If you do not see other users, re-check the radio preset first, then confirm the path hash mode is set to 3-byte.
+
+## First Success Checklist
+
+- Your device shows the **USA/Canada (Recommended)** preset, or the raw values match `910.525 MHz / 62.5 kHz / SF7 / CR5`.
+- Path hash mode is **3-byte**.
+- The device was rebooted after radio changes.
+- A nearby community member or second known-good device can see your advert.
+- If this is an observer, [CoreScope](https://live.meshcore.ca/#/observers) shows the expected node name and IATA region.
 
 ## Need Help?
 

--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -2,37 +2,65 @@
 
 A quick reference for common terms used across the MeshCore community.
 
-!!! info "This page is a work in progress"
-    Content coming soon. Want to help? See [Contributing](../contributing.md).
+**Advert**
+:   A MeshCore announcement packet that helps nearby nodes learn about a device and route.
 
-<!-- TODO: Fill in definitions, add more terms as needed -->
+**Bandwidth**
+:   A LoRa radio setting. MeshCore Canada baseline raw settings use `62.5 kHz`.
+
+**Broker**
+:   An MQTT server. MeshCore.ca uses `mqtt1.meshcore.ca` and `mqtt2.meshcore.ca` for redundant observer publishing.
+
+**Coding Rate (CR)**
+:   A LoRa error-correction setting. MeshCore Canada baseline raw settings use `CR5`.
 
 **Companion**
-:   <!-- TODO: A portable MeshCore device used to send and receive messages -->
+:   A portable MeshCore device used with a phone, tablet, desktop app, web app, or serial client to send and receive messages.
+
+**CoreScope**
+:   The MeshCore.ca live tools for checking observers, packet flow, and map data.
+
+**IATA Code**
+:   A real 3-letter airport code used by MeshCore.ca observers to tag their region, such as `YOW`, `YYZ`, or `YVR`.
 
 **ISM Band**
-:   <!-- TODO: Industrial, Scientific, and Medical radio band, license-free frequencies -->
+:   Industrial, Scientific, and Medical radio spectrum used by many low-power devices. You are responsible for legal operation in your location.
+
+**JWT**
+:   JSON Web Token. MeshCore.ca MQTT paths use token authentication instead of a static username/password.
 
 **LoRa**
-:   <!-- TODO: Long Range, the radio modulation technology MeshCore uses -->
+:   Long Range radio modulation used by MeshCore devices.
 
 **Mesh Network**
-:   <!-- TODO: A network where devices relay messages for each other -->
+:   A network where devices can relay traffic for each other instead of depending on one central access point.
 
 **MQTT**
-:   <!-- TODO: Message Queuing Telemetry Transport, a lightweight messaging protocol -->
+:   A lightweight publish/subscribe messaging protocol used by MeshCore.ca observers to publish packet telemetry.
 
 **Node**
-:   <!-- TODO: Any device on the mesh network -->
+:   Any MeshCore device on the network.
+
+**Observer**
+:   A MeshCore radio or host service that publishes mesh packet telemetry to MQTT for live tools.
+
+**Path Hash Mode**
+:   The MeshCore setting that controls advert path identifier size. MeshCore Canada recommends **3-byte**, which is `set path.hash.mode 2` in the CLI.
+
+**Preset**
+:   A named group of radio settings. MeshCore Canada generally uses `USA/Canada (Recommended)`.
 
 **Repeater**
-:   <!-- TODO: A fixed device that relays messages to extend mesh coverage -->
+:   A fixed device that relays packets to extend mesh coverage.
 
 **Room Server**
-:   <!-- TODO: A MeshCore node that hosts group chat rooms -->
+:   A MeshCore node that hosts group chat rooms. It may also repeat or observe traffic depending on its configuration.
 
 **SNR**
-:   <!-- TODO: Signal-to-Noise Ratio, a measure of signal quality -->
+:   Signal-to-noise ratio, a measure of received signal quality.
 
 **Spreading Factor (SF)**
-:   <!-- TODO: LoRa parameter that affects range vs speed tradeoff -->
+:   A LoRa setting that affects range, airtime, and data rate. MeshCore Canada baseline raw settings use `SF7`.
+
+**WebSockets**
+:   A transport used by the MeshCore.ca MQTT brokers on port `443`, which is often easier to pass through normal internet connections.

--- a/docs/resources/links.md
+++ b/docs/resources/links.md
@@ -1,28 +1,59 @@
 # Useful Links
 
-!!! info "This page is a work in progress"
-    Content coming soon. Want to help? See [Contributing](../contributing.md).
+This page collects common MeshCore, MeshCore Canada, and supporting radio resources.
+
+## MeshCore Canada
+
+| Resource | Link |
+|----------|------|
+| MeshCore Canada site | <https://meshcore.ca/> |
+| Live CoreScope tools | <https://live.meshcore.ca/> |
+| MeshCore Canada GitHub | <https://github.com/MeshCore-ca/MeshCore-Canada> |
+| Add or update a community | [Contributing](../contributing.md) |
+| Mesh Directory | [Browse provinces and territories](../provinces/index.md) |
 
 ## Official MeshCore
 
-<!-- TODO: MeshCore GitHub, firmware downloads, official docs -->
+| Resource | Link |
+|----------|------|
+| MeshCore website | <https://meshcore.io/> |
+| MeshCore docs | <https://docs.meshcore.io/> |
+| MeshCore source | <https://github.com/meshcore-dev/MeshCore> |
+| MeshCore GitHub organization | <https://github.com/meshcore-dev> |
+| MeshCore Flasher | <https://flasher.meshcore.io/> |
+| Repeater / room-server USB config | <https://config.meshcore.io/> |
+| MeshCore web app | <https://app.meshcore.nz/> |
 
-## Community
+## MeshCore.ca Analyzer
 
-<!-- TODO: Discord servers, forums, social media groups -->
+| Resource | Link |
+|----------|------|
+| Observer setup overview | [Analyzer & MQTT](../analyzer/intro.md) |
+| Direct MQTT firmware | [MQTT Firmware](../analyzer/builds/mqtt-firmware.md) |
+| MCtoMQTT host bridge | [MCtoMQTT](../analyzer/builds/mctomqtt.md) |
+| Home Assistant integration setup | [MeshCore-HA](../analyzer/builds/meshcore-ha.md) |
+| PyMC setup | [PyMC](../analyzer/builds/pymc.md) |
+| RemoteTerm setup | [RemoteTerm](../analyzer/remoteterm.md) |
+| IATA code reference | [IATA Region Codes](../analyzer/iata-codes.md) |
 
-## Canadian Resources
+## Radio And Regulatory References
 
-<!-- TODO: ISED regulations, frequency allocations, RAC (Radio Amateurs of Canada) -->
+| Resource | Link |
+|----------|------|
+| Innovation, Science and Economic Development Canada | <https://ised-isde.canada.ca/> |
+| Radio Amateurs of Canada | <https://www.rac.ca/> |
 
-## Hardware Vendors
+!!! note "Regulatory links"
+    MeshCore Canada docs are not legal advice. Check current ISED rules and any licence conditions that apply to your station before changing power, antenna gain, frequency, or duty cycle.
 
-<!-- TODO: Canadian-friendly vendors for LoRa devices, antennas, enclosures, solar panels -->
+## Tools
 
-## Tools & Software
+| Tool | Use |
+|------|-----|
+| MeshCore Flasher | Flash supported MeshCore firmware and custom binaries |
+| MeshCore USB config | Configure repeaters and room servers over serial |
+| RemoteTerm | Manage radios and optionally publish packets through Community MQTT |
+| CoreScope | Check observers, packets, and map visibility |
+| MQTT clients | Advanced broker diagnostics when troubleshooting observer paths |
 
-<!-- TODO: Firmware flashers, serial monitors, MQTT clients, mapping tools -->
-
-## Related Projects
-
-<!-- TODO: Meshtastic, APRS, other mesh/LoRa projects -->
+When in doubt, start with [Getting Started](getting-started.md), then move to the hardware or observer guide that matches your device role.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,9 @@ nav:
       - Overview: analyzer/intro.md
       - Check Your Observer: analyzer/verify.md
       - Troubleshooting: analyzer/troubleshooting.md
+      - Broker Reference: analyzer/broker-reference.md
+      - IATA Region Codes: analyzer/iata-codes.md
+      - RemoteTerm: analyzer/remoteterm.md
       - Build Guides:
           - MCtoMQTT Script: analyzer/builds/mctomqtt.md
           - MeshCore-HA: analyzer/builds/meshcore-ha.md


### PR DESCRIPTION
## Summary
- Fills the placeholder MeshCore and Resources pages with practical beginner, hardware, antenna, glossary, and link content.
- Refactors the Analyzer overview into smaller reference pages for broker settings, IATA region codes, and RemoteTerm setup, while keeping the observer path selector concise.
- Adds a static firmware download fallback, updates observer verification/troubleshooting for RemoteTerm, and removes stale wording from MQTT firmware docs.
- Normalizes Mesh Directory pages with consistent community fields, baseline radio/path settings, clearer empty-province pages, and fixed malformed links.
- Includes the guided Heltec V3/V4 MQTT firmware setup helpers from PR #23, including both Bash and Windows PowerShell entrypoints, so this docs PR will not overwrite or drop that setup path if it lands later.

## Live site check
- PR #20 is merged in GitHub, but the live site still appeared stale when this PR was opened: the homepage still linked Mesh Directory to Ontario, Getting Started was still the placeholder, and MQTT Firmware still listed RAK3112.
- This PR is based on current `origin/main` at `395a0bd` so it takes PR #20 into account in source.

## Validation
- `bash -n docs/analyzer/scripts/setup-mqtt-firmware.sh`
- `docs/analyzer/scripts/setup-mqtt-firmware.sh --print-only --board heltec-v3 --role repeater --iata YOW --name YOW-Repeater-01 --wifi-ssid TestNetwork --wifi-password TestPassword --restore-brokers --repeat`
- `docs/analyzer/scripts/setup-mqtt-firmware.sh --print-only --board heltec-v4-oled --role room-server --iata YVR --name YVR-Room-Server-01 --wifi-ssid MeshLab --wifi-password Secret123 --no-restore-brokers --observe-only`
- Windows helper reviewed statically; PowerShell is not installed in this local environment, so `setup-mqtt-firmware.ps1` was not executed here.
- `git diff --check origin/main...HEAD`
- `grep -RIn "MrAlders0n/MeshCore-Canada\|Laymen\|four paths\|four observer\|WIP\|TODO\|Content coming soon\|hhttps\|Analyzer Overview" docs mkdocs.yml` returned no matches
- `python3 scripts/normalize-firmware-assets.py --check docs/analyzer/builds/firmware`
- `python3 -m json.tool docs/analyzer/builds/firmware/manifest.json >/tmp/meshcore-manifest-check.json`
- `cmp docs/analyzer/builds/firmware/manifest.json scripts/firmware-manifest.json`
- `/tmp/meshcore-ca-mkdocs-venv/bin/mkdocs build --strict`