### PR TITLE
[codex] Add homepage Discord link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,10 @@ hide:
 ---
 # MeshCore Canada
 
+<div class="home-discord-link" markdown>
+[:fontawesome-brands-discord:](https://discord.gg/BESFVMt7yk){ .discord-logo-link aria-label="Join the MeshCore Canada Discord" title="Join the MeshCore Canada Discord" target="_blank" rel="noopener" }
+</div>
+
 !!! warning "Community Project"
     **meshcore.ca** is an independent community site. We're not affiliated with, endorsed by, or officially connected to the MeshCore or MeshOS projects. We're just a group of Canadians helping other Canadians organize their local meshes and build useful tools for the community.
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,46 @@
+.home-discord-link {
+  display: flex;
+  justify-content: center;
+  margin: 0 0 1rem;
+}
+
+.home-discord-link p {
+  margin: 0;
+}
+
+.home-discord-link .discord-logo-link {
+  align-items: center;
+  border: 1px solid rgba(88, 101, 242, 0.45);
+  border-color: color-mix(in srgb, #5865f2 45%, transparent);
+  border-radius: 0.4rem;
+  color: #5865f2;
+  display: inline-flex;
+  height: 3rem;
+  justify-content: center;
+  transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease;
+  width: 3rem;
+}
+
+.home-discord-link .discord-logo-link:hover,
+.home-discord-link .discord-logo-link:focus-visible {
+  background-color: #5865f2;
+  border-color: #5865f2;
+  color: #fff;
+}
+
+.home-discord-link .discord-logo-link:focus-visible {
+  outline: 2px solid var(--md-accent-fg-color);
+  outline-offset: 3px;
+}
+
+.home-discord-link .twemoji {
+  display: inline-flex;
+  height: 1.75rem;
+  width: 1.75rem;
+}
+
+.home-discord-link .twemoji svg {
+  fill: currentColor;
+  height: 100%;
+  width: 100%;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,9 @@ theme:
     - navigation.top
     - toc.follow
 
+extra_css:
+  - stylesheets/extra.css
+
 markdown_extensions:
   - admonition
   - attr_list


### PR DESCRIPTION
## Summary

Adds a centered Discord logo link near the top of the meshcore.ca homepage so visitors can join the new Discord server.

## Changes

- Added the Discord invite link to `docs/index.md` using the existing Material icon pipeline.
- Added a small custom stylesheet for centering, hover, and keyboard focus states.
- Registered the stylesheet through `mkdocs.yml`.

## Validation

- Ran `/tmp/meshcore-mkdocs-venv/bin/mkdocs build --strict --site-dir /tmp/meshcore-site-build`.
