### PR TITLE
[codex] Update YQB Discord invite

### DIFF
--- a/docs/provinces/quebec.md
+++ b/docs/provinces/quebec.md
@@ -37,7 +37,7 @@ If you know of a community that is missing or needs an update, open an update re
 | Radio preset | `USA/Canada (Recommended)` |
 | Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
 | Path hash mode | `3-byte` |
-| Discord | <https://discord.com/channels/1497584274520412223> |
+| Discord | <https://discord.gg/UhGjTF2MfA> |
 
 ### Réseau Libre
 


### PR DESCRIPTION
## What changed

Updates the Discord link for `Réseau Mesh de la Capitale YQB` on the Quebec communities page to the non-expiring invite requested in #26:

`https://discord.gg/UhGjTF2MfA`

## Why

The current entry points at a Discord channel URL instead of the permanent invite supplied by the community.

Fixes #26.

## Validation

- `git diff --check`
- `/tmp/meshcore-ca-venv/bin/mkdocs build --strict`