### PR TITLE
[codex] Clarify YTR region picker behavior

### DIFF
--- a/docs/analyzer/builds/meshcore-ha.md
+++ b/docs/analyzer/builds/meshcore-ha.md
@@ -69,12 +69,15 @@ Current MeshCore-HA versions use a free-text **Broker IATA Code** field, so you 
 !!! tip
     You can find common Canadian IATA codes on the [IATA Region Codes](../iata-codes.md) page. If your nearest real airport code is missing from that quick list, you can still use it.
 
+    The CoreScope/live region picker is based on currently observed traffic. A valid code can be missing from that picker until an observer publishes under it.
+
 ## Common HA Symptoms
 
 | Symptom | Most likely fix |
 |---------|-----------------|
 | Brokers show connected but no packets appear | Enable **Packets (Lets Mesh)** or set **Payload Mode** to `packet` |
 | `YTR` or another code is not selectable | Update MeshCore-HA, then type the code in **Broker IATA Code** |
+| Code is valid but absent from the live region picker | Keep the real code; the picker appears after current traffic is observed |
 | One broker works and the backup does not | Check the second broker's **Token Audience** is `mqtt2.meshcore.ca` |
 | Packets appear under the wrong city | Set both broker IATA fields to the nearest real airport code |
 

--- a/docs/analyzer/iata-codes.md
+++ b/docs/analyzer/iata-codes.md
@@ -4,6 +4,8 @@ Each observer identifies its region with a real 3-letter IATA airport code. Use 
 
 The firmware and helper scripts are not limited to the list below. If your nearest real IATA code is missing here, you can still use it and the public broker will accept it as long as it is a valid airport code. The live site will add observed regions to the picker automatically, but codes missing from the friendly-name list may appear as the bare code until we add a label.
 
+The live region picker is traffic-driven. If a valid code such as `YTR` is absent from the picker, that usually means no current observer is publishing packet or status traffic under that code; it does not mean the broker rejects the code.
+
 Do not use placeholders or made-up region names such as `XXX` or `HOME`. Do not use `CAN` as shorthand for Canada; it is a real airport code for Guangzhou and will tag your observer to the wrong region.
 
 Host-side helper scripts show this same quick list interactively when you omit `--iata`.

--- a/docs/analyzer/troubleshooting.md
+++ b/docs/analyzer/troubleshooting.md
@@ -91,10 +91,13 @@ If the brokers connect but packets never appear, check the packet payload settin
 
 If a code such as `YTR` is missing from a picker, update the MeshCore Home Assistant integration and type the code into **Broker IATA Code**. Using a nearby code such as `YGK` can make data visible, but it tags the observer to the wrong region.
 
+If the code is missing from the CoreScope/live region picker, keep using the real IATA code anyway. The picker reflects currently observed traffic; it does not define which valid codes the broker accepts.
+
 | HA symptom | Check |
 |------------|-------|
 | Broker connected, no packets | **Packets (Lets Mesh)** enabled or **Payload Mode** = `packet` |
 | Cannot enter a real IATA code | Update MeshCore-HA; current versions use free text |
+| Real code missing from live picker | Wait for current observer traffic under that code; do not switch to a neighboring region |
 | Backup broker fails | `Token Audience` must match the broker host (`mqtt2.meshcore.ca`) |
 | Observer appears under the wrong city | Both broker entries use the same nearest real IATA code |
 


### PR DESCRIPTION
## Summary

Addresses #25.

This updates the Analyzer/MQTT docs to make the YTR behavior explicit:

- valid IATA codes can be accepted by the broker even when absent from the live region picker
- the CoreScope/live region picker is driven by currently observed traffic
- users should keep the real local IATA code instead of switching to a neighboring region such as YGK

## Investigation Notes

I performed a read-only investigation on `mqtt1.meshcore.ca`. The broker is up behind Caddy, and the custom `meshcore-mqtt.service` is actively accepting WebSocket MQTT traffic. Broker logs show `YTR` publishes and status messages being authorized on May 24, 2026, so `YTR` is not rejected by the MQTT server. The installed `airport-utils` package also resolves `YTR`, `YGK`, and `YOW` as valid airport codes.

The logs also showed a separate Home Assistant-style client repeatedly connecting without an MQTT username, which the broker rejects before any IATA authorization path. That points to a missing/disabled MeshCore auth-token setup rather than a broker-side YTR validation failure.

## Validation

- `mkdocs build --strict --site-dir %TEMP%/meshcore-site-check`
- verified generated pages contain the new YTR/live-picker guidance
- read-only service/log inspection on `mqtt1.meshcore.ca`