### PR TITLE
[codex] Add MQTT data and admin access docs

### DIFF
--- a/docs/analyzer/data-collection-access.md
+++ b/docs/analyzer/data-collection-access.md
@@ -44,3 +44,5 @@ The MeshCore Canada infrastructure administrators control the MQTT brokers and r
 | Kranic | [forum.meshcore.ca/u/djkranic](https://forum.meshcore.ca/u/djkranic) |
 
 Questions about privacy, MQTT access, or the MeshCore Canada project should be directed to these administrators.
+
+General discussion and support is also available on the forum at [https://forum.meshcore.ca/](https://forum.meshcore.ca/).

--- a/docs/analyzer/data-collection-access.md
+++ b/docs/analyzer/data-collection-access.md
@@ -1,7 +1,7 @@
 # MQTT Data Collection & Access
 
-!!! warning "Treat MeshCore RF traffic as public data"
-    MeshCore traffic is intended for shared mesh use, and different networks may use different presets or frequencies (including non-default settings). Any node transmitting MeshCore packets over matching settings can be heard by observers on that mesh, not just one published default profile. Traffic forwarded over MQTT through this path should be treated as potentially public. Do not transmit names, locations, notes, or other personal information unless you are comfortable with that information being stored and viewable publicly. Assume that even with encryption on a private channel / setting can potentially be collected and decrypted by anyone with the means and know-how to do so.
+!!! warning "Treat MeshCore RF traffic as public data" !!!
+    MeshCore traffic is intended for shared mesh use, and different networks may use different presets or frequencies (including non-default settings). All channels that use a shared public key (and private keys) should be considered inherantly insecure. Any node transmitting MeshCore packets over matching settings can be heard by observers on that mesh, not just one published default profile. Traffic forwarded over MQTT through this path should be treated as potentially public. Do not transmit names, locations, notes, or other personal information unless you are comfortable with that information being stored and viewable publicly. Assume that even with encryption on a private channel / setting can potentially be collected and decrypted by anyone with the means and know-how to do so.
 
 ## What We Collect
 
@@ -13,7 +13,7 @@ Observers listen for all MeshCore traffic they can hear on the channels and pres
 
 For companion/client paths that expose controls, users can opt in or opt out of telemetry and location data uploading as part of their observer setup.
 
-It is each user's responsibility to choose how much personal information to share from their radios over MQTT. If telemetry, location, or identifying profile information is enabled on a client, that data may be published, stored, and displayed by public viewer sites.
+It is each user's responsibility to choose how much personal information to share from their radios over MQTT. If telemetry, location, or identifying profile information is enabled on a client, that data may be published, stored, and displayed by public viewer sites. Double check your settings.
 
 ## Where Data Goes
 

--- a/docs/analyzer/data-collection-access.md
+++ b/docs/analyzer/data-collection-access.md
@@ -24,9 +24,7 @@ Direct MQTT subscription access is not handed out to everyone. It is limited to 
 
 Even when direct broker subscription access is limited, the data can still be viewable by everyone through Beacon, CoreScope, and other public websites that consume the MQTT feed using approved MQTT read accounts.
 
-## MQTT Read Access Inventory
-
-Keep this list updated whenever a tool, service, or public website receives a new MQTT read account.
+## MQTT Read Access
 
 | Tool or service | Operator | Purpose |
 |-----------------|----------|---------|

--- a/docs/analyzer/data-collection-access.md
+++ b/docs/analyzer/data-collection-access.md
@@ -1,7 +1,5 @@
 # MQTT Data Collection & Access
 
-This page explains where MeshCore Canada MQTT data goes, who can access the broker feeds, and who administers the infrastructure.
-
 !!! warning "Treat Public channel traffic as public"
     MeshCore Canada observers operate on the default MeshCore Canada network settings and Public channel. The default MeshCore encryption system and Public channel are for shared public mesh traffic, not private distribution to a closed group. Traffic sent on the Public channel should be treated as public. Do not transmit names, locations, notes, or other personal information over radio or MQTT unless you are comfortable with that information being stored and shown publicly.
 

--- a/docs/analyzer/data-collection-access.md
+++ b/docs/analyzer/data-collection-access.md
@@ -1,0 +1,46 @@
+# MQTT Data Collection & Access
+
+This page explains where MeshCore Canada MQTT data goes, who can access the broker feeds, and who administers the infrastructure.
+
+!!! warning "Treat Public channel traffic as public"
+    MeshCore Canada observers operate on the default MeshCore Canada network settings and Public channel. The default MeshCore encryption system and Public channel are for shared public mesh traffic, not private distribution to a closed group. Traffic sent on the Public channel should be treated as public. Do not transmit names, locations, notes, or other personal information over radio or MQTT unless you are comfortable with that information being stored and shown publicly.
+
+## What We Collect
+
+MeshCore Canada collects packet data from nodes that are on the MeshCore Canada network and are seen by an observer.
+
+Observers listen for all traffic they can hear on the default MeshCore Canada frequencies and settings. If a packet is heard by an observer and the observer path is configured to publish packet data, it can be sent to the MeshCore Canada MQTT brokers.
+
+## User Control
+
+Users can opt in or opt out of telemetry and location data uploading in their MeshCore clients where those settings are available.
+
+It is each user's responsibility to choose how much personal information to share from their radios over MQTT. If telemetry, location, or identifying profile information is enabled on a client, that data may be published, stored, and displayed by public viewer sites.
+
+## Where Data Goes
+
+| Step | What happens |
+|------|--------------|
+| Radio traffic | Nodes transmit on the MeshCore Canada default frequencies and Public channel. |
+| Observer capture | MeshCore Canada observers listen to all traffic they can hear on those defaults. |
+| MQTT publish | Observer paths publish packet data to MeshCore Canada MQTT infrastructure. |
+| Storage and display | Data is stored on MeshCore Canada infrastructure and may be displayed by Beacon and other public websites operated by MeshCore Canada operators. |
+
+## MQTT Subscription Access
+
+Direct MQTT subscription access is not handed out to everyone. It is limited to local mesh administrators and people approved by MeshCore Canada administration.
+
+Even when direct broker subscription access is limited, the data can still be viewable by everyone through Beacon and other public websites that consume the MQTT feed using the MQTT subscription role.
+
+## Infrastructure Administrators
+
+The MeshCore Canada infrastructure administrators control the MQTT brokers and related infrastructure.
+
+| Administrator | Profile |
+|---------------|---------|
+| Mr. Alderson | [github.com/MrAlders0n](https://github.com/MrAlders0n) |
+| Ded | [github.com/446564](https://github.com/446564) |
+| n30nex | [github.com/n30nex](https://github.com/n30nex) |
+| Kranic | [forum.meshcore.ca/u/djkranic](https://forum.meshcore.ca/u/djkranic) |
+
+Questions about privacy, MQTT access, or the MeshCore Canada project should be directed to these administrators.

--- a/docs/analyzer/data-collection-access.md
+++ b/docs/analyzer/data-collection-access.md
@@ -1,17 +1,19 @@
 # MQTT Data Collection & Access
 
-!!! warning "Treat Public channel traffic as public"
-    MeshCore Canada observers operate on the default MeshCore Canada network settings and Public channel. The default MeshCore encryption system and Public channel are for shared public mesh traffic, not private distribution to a closed group. Traffic sent on the Public channel should be treated as public. Do not transmit names, locations, notes, or other personal information over radio or MQTT unless you are comfortable with that information being stored and shown publicly.
+This page explains where MeshCore Canada MQTT data goes, who can access the broker feeds, and who administers the infrastructure.
+
+!!! warning "Treat MeshCore RF traffic as potentially public"
+    MeshCore traffic is intended for shared mesh use, and different networks may use different presets or frequencies (including non-default settings). Any node transmitting MeshCore packets over matching settings can be heard by observers on that mesh, not just one published default profile. Traffic forwarded over MQTT through this path should be treated as potentially public. Do not transmit names, locations, notes, or other personal information unless you are comfortable with that information being stored and viewable publicly.
 
 ## What We Collect
 
-MeshCore Canada collects packet data from nodes that are on the MeshCore Canada network and are seen by an observer.
+MeshCore Canada MQTT receives packet data from observer nodes that capture MeshCore packets and forward telemetry from matched channels.
 
-Observers listen for all traffic they can hear on the default MeshCore Canada frequencies and settings. If a packet is heard by an observer and the observer path is configured to publish packet data, it can be sent to the MeshCore Canada MQTT brokers.
+Observers listen for all MeshCore traffic they can hear on the channels and presets they are configured for. If a packet is heard by an observer and that observer has packet publishing enabled, that traffic can be sent to the MeshCore Canada MQTT brokers.
 
 ## User Control
 
-Users can opt in or opt out of telemetry and location data uploading in their MeshCore clients where those settings are available.
+For companion/client paths that expose controls, users can opt in or opt out of telemetry and location data uploading as part of their observer setup.
 
 It is each user's responsibility to choose how much personal information to share from their radios over MQTT. If telemetry, location, or identifying profile information is enabled on a client, that data may be published, stored, and displayed by public viewer sites.
 
@@ -19,8 +21,8 @@ It is each user's responsibility to choose how much personal information to shar
 
 | Step | What happens |
 |------|--------------|
-| Radio traffic | Nodes transmit on the MeshCore Canada default frequencies and Public channel. |
-| Observer capture | MeshCore Canada observers listen to all traffic they can hear on those defaults. |
+| Radio traffic | Nodes transmit MeshCore packets on the frequencies and settings configured for their local mesh and presets. |
+| Observer capture | MeshCore Canada observers and other authorized observers listen to all traffic they can hear on their configured channels. |
 | MQTT publish | Observer paths publish packet data to MeshCore Canada MQTT infrastructure. |
 | Storage and display | Data is stored on MeshCore Canada infrastructure and may be displayed by Beacon and other public websites operated by MeshCore Canada operators. |
 

--- a/docs/analyzer/data-collection-access.md
+++ b/docs/analyzer/data-collection-access.md
@@ -16,13 +16,22 @@ Observers listen for all MeshCore traffic they can hear on the channels and pres
 | Radio traffic | Nodes transmit MeshCore packets on the frequencies and settings configured for their local mesh and presets. |
 | Observer capture | MeshCore Canada observers and other authorized observers listen to all traffic they can hear on their configured channels. |
 | MQTT publish | Observer paths publish packet data to MeshCore Canada MQTT infrastructure. |
-| Storage and display | Data is stored on MeshCore Canada infrastructure and may be displayed by Beacon and other public websites operated by MeshCore Canada operators. |
+| Storage and display | Data is stored on MeshCore Canada infrastructure and may be displayed by Beacon, CoreScope, and other public websites operated by MeshCore Canada or approved third-party operators. |
 
 ## MQTT Subscription Access
 
-Direct MQTT subscription access is not handed out to everyone. It is limited to local mesh administrators and people approved by MeshCore Canada administration.
+Direct MQTT subscription access is not handed out to everyone. It is limited to local mesh administrators, approved tools, and people approved by MeshCore Canada administration.
 
-Even when direct broker subscription access is limited, the data can still be viewable by everyone through Beacon and other public websites that consume the MQTT feed using the MQTT subscription role.
+Even when direct broker subscription access is limited, the data can still be viewable by everyone through Beacon, CoreScope, and other public websites that consume the MQTT feed using approved MQTT read accounts.
+
+## MQTT Read Access Inventory
+
+Keep this list updated whenever a tool, service, or public website receives a new MQTT read account.
+
+| Tool or service | Operator | Purpose |
+|-----------------|----------|---------|
+| Beacon | MeshCore Canada operators | Public viewer for MeshCore packet data. |
+| CoreScope (`live.meshcore.ca`) | MeshCore Canada operators | Public observer, packet, and map tools. |
 
 ## Infrastructure Administrators
 

--- a/docs/analyzer/data-collection-access.md
+++ b/docs/analyzer/data-collection-access.md
@@ -1,9 +1,7 @@
 # MQTT Data Collection & Access
 
-This page explains where MeshCore Canada MQTT data goes, who can access the broker feeds, and who administers the infrastructure.
-
-!!! warning "Treat MeshCore RF traffic as potentially public"
-    MeshCore traffic is intended for shared mesh use, and different networks may use different presets or frequencies (including non-default settings). Any node transmitting MeshCore packets over matching settings can be heard by observers on that mesh, not just one published default profile. Traffic forwarded over MQTT through this path should be treated as potentially public. Do not transmit names, locations, notes, or other personal information unless you are comfortable with that information being stored and viewable publicly.
+!!! warning "Treat MeshCore RF traffic as public data"
+    MeshCore traffic is intended for shared mesh use, and different networks may use different presets or frequencies (including non-default settings). Any node transmitting MeshCore packets over matching settings can be heard by observers on that mesh, not just one published default profile. Traffic forwarded over MQTT through this path should be treated as potentially public. Do not transmit names, locations, notes, or other personal information unless you are comfortable with that information being stored and viewable publicly. Assume that even with encryption on a private channel / setting can potentially be collected and decrypted by anyone with the means and know-how to do so.
 
 ## What We Collect
 

--- a/docs/analyzer/data-collection-access.md
+++ b/docs/analyzer/data-collection-access.md
@@ -1,7 +1,7 @@
 # MQTT Data Collection & Access
 
 !!! warning "Treat MeshCore RF traffic as public data" !!!
-    MeshCore traffic is intended for shared mesh use, and different networks may use different presets or frequencies (including non-default settings). All channels that use a shared public key (and private keys) should be considered inherantly insecure. Any node transmitting MeshCore packets over matching settings can be heard by observers on that mesh, not just one published default profile. Traffic forwarded over MQTT through this path should be treated as potentially public. Do not transmit names, locations, notes, or other personal information unless you are comfortable with that information being stored and viewable publicly. Assume that even with encryption on a private channel / setting can potentially be collected and decrypted by anyone with the means and know-how to do so.
+    MeshCore traffic is intended for shared mesh use, and different networks may use different presets or frequencies (including non-default settings). All channels that use a shared public key (and private keys) should be considered inherently insecure. Any node transmitting MeshCore packets over matching settings can be heard by observers on that mesh, not just one published default profile. Traffic forwarded over MQTT through this path should be treated as potentially public. Do not transmit names, locations, notes, or other personal information unless you are comfortable with that information being stored and viewable publicly. Assume that even with encryption on a private channel / setting can potentially be collected and decrypted by anyone with the means and know-how to do so.
 
 ## What We Collect
 

--- a/docs/analyzer/data-collection-access.md
+++ b/docs/analyzer/data-collection-access.md
@@ -9,12 +9,6 @@ MeshCore Canada MQTT receives packet data from observer nodes that capture MeshC
 
 Observers listen for all MeshCore traffic they can hear on the channels and presets they are configured for. If a packet is heard by an observer and that observer has packet publishing enabled, that traffic can be sent to the MeshCore Canada MQTT brokers.
 
-## User Control
-
-For companion/client paths that expose controls, users can opt in or opt out of telemetry and location data uploading as part of their observer setup.
-
-It is each user's responsibility to choose how much personal information to share from their radios over MQTT. If telemetry, location, or identifying profile information is enabled on a client, that data may be published, stored, and displayed by public viewer sites. Double check your settings.
-
 ## Where Data Goes
 
 | Step | What happens |

--- a/docs/analyzer/intro.md
+++ b/docs/analyzer/intro.md
@@ -91,6 +91,14 @@ MeshCore observers capture mesh traffic and publish packet telemetry to MQTT bro
 
     [:octicons-arrow-right-24: Broker Details](broker-reference.md)
 
+-   :material-eye:{ .lg .middle } **Data Collection & Access**
+
+    ---
+
+    Learn what observer data is collected, where it is stored, and who administers MQTT access.
+
+    [:octicons-arrow-right-24: Data Collection & Access](data-collection-access.md)
+
 -   :material-airplane:{ .lg .middle } **IATA Codes**
 
     ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ Whether you're brand new to mesh networking or looking to deploy repeaters acros
 
 We are a group of Canadian meshes across the country from British Columbia, Alberta, Ontario, and Quebec (hopefully more soon) that are working together to bring services and standards across Canada for all MeshCore users. We host MQTT servers and a packet analyzer at this site for all Canadians to use.
 
-The servers and services are currently managed by **MrAlders0n**, **Ded**, and **n30nex**.
+The servers and services are currently managed by [**Mr. Alderson**](https://github.com/MrAlders0n), [**Ded**](https://github.com/446564), [**n30nex**](https://github.com/n30nex), and [**Kranic**](https://forum.meshcore.ca/u/djkranic).
 
 The documentation on this site is open to all to contribute to and is backed by markdown files in GitHub at [MeshCore-ca/MeshCore-Canada](https://github.com/MeshCore-ca/MeshCore-Canada).
 

--- a/docs/resources/links.md
+++ b/docs/resources/links.md
@@ -7,6 +7,7 @@ This page collects common MeshCore, MeshCore Canada, and supporting radio resour
 | Resource | Link |
 |----------|------|
 | MeshCore Canada site | <https://meshcore.ca/> |
+| MeshCore Canada forum | <https://forum.meshcore.ca/> |
 | Live CoreScope tools | <https://live.meshcore.ca/> |
 | MeshCore Canada GitHub | <https://github.com/MeshCore-ca/MeshCore-Canada> |
 | Add or update a community | [Contributing](../contributing.md) |
@@ -29,6 +30,7 @@ This page collects common MeshCore, MeshCore Canada, and supporting radio resour
 | Resource | Link |
 |----------|------|
 | Observer setup overview | [Analyzer & MQTT](../analyzer/intro.md) |
+| MQTT data collection and access | [Data Collection & Access](../analyzer/data-collection-access.md) |
 | Direct MQTT firmware | [MQTT Firmware](../analyzer/builds/mqtt-firmware.md) |
 | MCtoMQTT host bridge | [MCtoMQTT](../analyzer/builds/mctomqtt.md) |
 | Home Assistant integration setup | [MeshCore-HA](../analyzer/builds/meshcore-ha.md) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Welcome: index.md
   - Analyzer & MQTT:
       - Overview: analyzer/intro.md
+      - Data Collection & Access: analyzer/data-collection-access.md
       - Check Your Observer: analyzer/verify.md
       - Troubleshooting: analyzer/troubleshooting.md
       - Broker Reference: analyzer/broker-reference.md
@@ -91,4 +92,5 @@ nav:
       - Getting Started: resources/getting-started.md
       - Useful Links: resources/links.md
       - Glossary: resources/glossary.md
+  - Forum: https://forum.meshcore.ca/
   - Contributing: contributing.md


### PR DESCRIPTION
## Summary
- Add an Analyzer & MQTT page explaining MQTT data collection, public-channel/default-encryption expectations, user telemetry/location controls, broker subscription limits, and public viewer exposure through Beacon and related sites.
- List the MeshCore Canada infrastructure administrators with profile links and update the homepage admin list to include Kranic.
- Add the new data/access page to the Analyzer nav and overview cards, add it to Useful Links, and add a top-level Forum nav link for the mobile/side drawer.

## Validation
- `mkdocs build --strict --site-dir $env:TEMP\meshcore-site-check`
- Local preview HTTP 200 for `/analyzer/data-collection-access/`
- In-app browser check confirmed the new page content/admins, the Analyzer drawer entry, and the top-level Forum link at mobile width.