### PR TITLE
Restructure nav: configurator link, Firmware Guides

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1,6 +1,7 @@
 ---
 title: Set up repeater regions
 hide:
+  - navigation
   - toc
 ---
 # Set up repeater regions

--- a/docs/meshcore/general-overview.md
+++ b/docs/meshcore/general-overview.md
@@ -30,6 +30,20 @@ Covers the most common questions about how MeshCore behaves on the Ottawa networ
 ### [MeshCore How-To](general-howto.md)
 Step-by-step walkthroughs for day-to-day tasks in the MeshCore mobile app, such as sharing your contact URL, importing contacts, and tracing routes. Each guide is visual and suitable for both new and experienced users.
 
+### [Repeater Configurator](../config/index.md)
+An interactive tool that finds the right Canadian region for a repeater and produces the exact commands to configure it — radio settings, region path, and verification steps. Also includes the [region map](../config/map.md) and the [region standard](../config/standard.md).
+
+### Firmware Guides
+Everything you need to get firmware onto a device:
+
+- [Flashing a Companion](flash-companion.md)
+- [Flashing a Repeater](flash-repeater.md)
+- [Updating a Repeater (OTA)](update-repeater-ota.md)
+- [Generating a Repeater ID](generate-repeater-id.md)
+- [Flashing a Room Server](flash-room-server.md)
+- [RAK4631 Custom Display Firmware](firmware-rak-custom-display.md)
+- [Heltec V3 Wi-Fi Firmware](firmware-heltec-v3-wifi.md)
+
 ---
 
 ## New to MeshCore?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,8 @@ nav:
           - MeshCore FAQ: meshcore/general-faq.md
           - MeshCore How-To: meshcore/general-howto.md
           - MeshCore Roles: meshcore/general-meshcore-roles.md
-      - Configuration:
+          - Repeater Configurator: /config/
+      - Firmware Guides:
           - Flashing a Companion:  meshcore/flash-companion.md
           - Flashing a Repeater: meshcore/flash-repeater.md
           - Updating a Repeater (OTA): meshcore/update-repeater-ota.md
@@ -87,11 +88,6 @@ nav:
           - Flashing a Room Server: meshcore/flash-room-server.md
           - RAK4631 Custom Display Firmware: meshcore/firmware-rak-custom-display.md
           - Heltec V3 Wi-Fi Firmware:  meshcore/firmware-heltec-v3-wifi.md
-
-  - Config:
-      - Configure a Node: config/index.md
-      - Map: config/map.md
-      - Region Standard: config/standard.md
 
   - Mesh Directory:
       - Overview: provinces/index.md


### PR DESCRIPTION
- Removes the Config nav section; the configurator now appears as a plain link (Repeater Configurator → /config/) under MeshCore → General
- Map and Region Standard stay published and linked from the configurator and overview pages, just not in the nav
- Renames MeshCore → Configuration to Firmware Guides
- General → Overview now introduces the Repeater Configurator and lists all Firmware Guides