### PR TITLE
Resolve community listings and repeater settings issues

### DIFF
--- a/docs/provinces/quebec.md
+++ b/docs/provinces/quebec.md
@@ -39,6 +39,19 @@ If you know of a community that is missing or needs an update, open an update re
 | Path hash mode | `3-byte` |
 | Discord | <https://discord.gg/UhGjTF2MfA> |
 
+### Réseau Mesh du Saguenay Lac st-Jean YTF
+
+| Field | Value |
+|-------|-------|
+| Region | Saguenay–Lac-Saint-Jean (YTF) |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Discord | <https://discord.gg/wUR394yXt> |
+| Facebook | <https://www.facebook.com/share/g/1GjkHAyZAM/> |
+| MeshMapper | <https://ytf.meshmapper.net/> |
+
 ### Réseau Libre
 
 | Field | Value |

--- a/docs/provinces/saskatchewan.md
+++ b/docs/provinces/saskatchewan.md
@@ -1,17 +1,18 @@
 # MeshCore Communities in Saskatchewan
 
-This page is ready for Saskatchewan MeshCore community listings.
+This page lists MeshCore communities in Saskatchewan.
 
-## Current Status
+If you know of a community that is missing or needs an update, open an update request through [Contributing](../contributing.md).
 
-No Saskatchewan community listing has been submitted yet.
+## Communities
 
-If you operate or know of a Saskatchewan MeshCore group, open an update request through [Contributing](../contributing.md) with the community name, region, status, contact link, and radio settings.
+### StoonMesh
 
-## Default Settings
-
-| Setting | Value |
-|---------|-------|
+| Field | Value |
+|-------|-------|
+| Region | Central Saskatchewan |
+| Status | Active |
 | Radio preset | `USA/Canada (Recommended)` |
 | Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
-| Path hash mode | `3-byte` |
+| Path hash mode | `1-byte` |
+| Discord | <https://discord.gg/7yGnJuMGkG> |

--- a/docs/resources/getting-started.md
+++ b/docs/resources/getting-started.md
@@ -55,6 +55,16 @@ set path.hash.mode 2
 
 After changing radio parameters, reboot the device.
 
+### Optional repeater loop protection
+
+Loop detection is not part of the Canada-wide basic setup. MeshCore leaves it off by default. If local operators are troubleshooting a packet storm caused by a looping repeater, firmware 1.14 and newer can use:
+
+```text
+set loop.detect moderate
+```
+
+This is a troubleshooting safeguard for repeaters, not a setting to apply to every new device. Coordinate the change with the local mesh, and leave it off when there is no loop problem. See the [upstream MeshCore CLI reference](https://github.com/meshcore-dev/MeshCore/blob/main/docs/cli_commands.md#view-or-change-this-nodes-loop-detection) for the available modes.
+
 ## Step 4: Configure Your Role
 
 | Role | Next setup step |


### PR DESCRIPTION
## Summary

- add StoonMesh to the Saskatchewan directory using the submitted Central Saskatchewan radio settings and Discord link
- add Réseau Mesh du Saguenay Lac st-Jean YTF to the Quebec directory with its Discord, Facebook, and MeshMapper links
- resolve the remaining repeater CLI discussion by keeping loop detection out of basic onboarding and documenting `set loop.detect moderate` as optional firmware 1.14+ troubleshooting

## Why

The repository had three open issues: two complete community submissions that had not reached the directory, and one settings discussion partly addressed by #20. This change publishes the submitted community information and records a clear, conservative policy for loop detection based on the current upstream MeshCore CLI behavior.

## Impact

Users in Central Saskatchewan and Saguenay–Lac-Saint-Jean can find their local communities and settings. New users are not told to change MeshCore's default loop-detection setting unnecessarily, while repeater operators have a documented safeguard when diagnosing packet loops.

Closes #16
Closes #38
Closes #43

## Validation

- `node scripts/validate-regions.js`
- `python scripts/verify-region-geometry.py`
- `python scripts/verify-region-geometry.py --partition docs/assets/regions/canada-region-partition-digital.geojson`
- `node --test tests/editor/validate.test.mjs` (18 passed)
- `node --check docs/config/editor/app.js`
- `mkdocs build --strict`
- `git diff --check`