### PR TITLE
Restore the configurator and simplify Share an Idea

### DIFF
--- a/.github/ISSUE_TEMPLATE/community_idea.yml
+++ b/.github/ISSUE_TEMPLATE/community_idea.yml
@@ -86,6 +86,13 @@ body:
       description: Optional Discord, forum, or GitHub username. Avoid posting an email address.
       placeholder: "@meshfriend on Discord"
 
+  - type: input
+    id: source_page
+    attributes:
+      label: Source page
+      description: The MeshCore Canada page that prepared this issue.
+      value: https://meshcore.ca/submit-idea/
+
   - type: checkboxes
     id: public
     attributes:

--- a/.github/ISSUE_TEMPLATE/community_idea.yml
+++ b/.github/ISSUE_TEMPLATE/community_idea.yml
@@ -1,5 +1,5 @@
 name: Share a Community Idea
-description: Suggest an improvement without needing code, Git, or perfect MeshCore terminology.
+description: Suggest an improvement or report a problem.
 title: "[Community idea] "
 labels: ["enhancement"]
 assignees: []
@@ -7,14 +7,14 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping MeshCore Canada improve. Describe what you experienced in your own words.
-        You do not need to know the technical solution. Please do not post passwords, private channel keys, API tokens, exact home addresses, or private coordinates.
+        Share an idea or report a problem.
+        Do not include passwords, keys, addresses, or private coordinates.
 
   - type: dropdown
     id: category
     attributes:
       label: Contribution type
-      description: Choose the closest match. Maintainers can re-categorize it later.
+      description: Choose the closest match.
       options:
         - Newcomer or accessibility improvement
         - Documentation correction
@@ -43,8 +43,8 @@ body:
     id: summary
     attributes:
       label: Short title
-      description: One sentence describing the idea or need.
-      placeholder: A printable checklist for first-time repeater installs
+      description: Briefly name the idea.
+      placeholder: Add a repeater checklist
     validations:
       required: true
 
@@ -52,24 +52,24 @@ body:
     id: region
     attributes:
       label: City or broad region
-      description: Optional. Do not include a home address or private coordinates.
+      description: Optional. No exact addresses.
       placeholder: Waterloo Region, Ontario
 
   - type: textarea
     id: need
     attributes:
-      label: What are you trying to do, or what is difficult today?
-      description: Tell us where you got stuck, what was missing, or what you observed.
-      placeholder: I was setting up my first node and could not tell whether...
+      label: What is difficult now?
+      description: What happened?
+      placeholder: I could not find...
     validations:
       required: true
 
   - type: textarea
     id: idea
     attributes:
-      label: What would make it better?
-      description: A rough idea is welcome. You do not need to design the complete solution.
-      placeholder: It would help if the site included...
+      label: What would help?
+      description: What should change?
+      placeholder: Add...
     validations:
       required: true
 
@@ -77,26 +77,26 @@ body:
     id: context
     attributes:
       label: Additional context
-      description: Optional device, app, page, screenshot description, prior attempt, or affected audience.
+      description: Optional device, app, page, or details.
 
   - type: input
     id: follow_up
     attributes:
       label: Public username or profile for follow-up
-      description: Optional Discord, forum, or GitHub username. Avoid posting an email address.
+      description: Optional public username. No email.
       placeholder: "@meshfriend on Discord"
 
   - type: input
     id: source_page
     attributes:
       label: Source page
-      description: The MeshCore Canada page that prepared this issue.
+      description: Page that opened this form.
       value: https://meshcore.ca/submit-idea/
 
   - type: checkboxes
     id: public
     attributes:
-      label: Public submission
+      label: Public
       options:
-        - label: I understand this submission is public and contains no secrets or precise private location information.
+        - label: This can be posted publicly and contains no private information.
           required: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -57,5 +57,8 @@ jobs:
           node --check docs/javascripts/community-submission.js
           node --check docs/javascripts/submission-form.js
 
+      - name: Validate community submission helper
+        run: python scripts/validate_community_submission.py
+
       - name: Build documentation
         run: mkdocs build --strict

--- a/docs/assets/regions/regions.js
+++ b/docs/assets/regions/regions.js
@@ -865,7 +865,7 @@
       : unique(nearbyTags.concat(state.selectedMetros));
     var hiddenCount = Math.max(0, allTags.length - visibleTags.length);
 
-    target.innerHTML = '<p class="mcc-hint">High-site repeaters can carry multiple local areas. Select every area this site is intended to serve.</p>' +
+    target.innerHTML = '<p class="mcc-hint">Select each region this high site will serve.</p>' +
       '<div class="mcc-chip-group"><strong>' + esc(provinceGroup ? provinceGroup.label : labelFor(data, provinceTag)) + '</strong><div class="mcc-chip-list">' +
           visibleTags.map(function (tag) {
             var checked = state.selectedMetros.indexOf(tag) !== -1 ? " checked" : "";
@@ -897,8 +897,8 @@
     if (!state.canGenerate) {
       target.innerHTML = '<div class="mcc-empty-state">' +
         icon("radio-tower") +
-        '<strong>No recommendation yet</strong>' +
-        '<span>Choose a Canadian location.</span>' +
+        '<strong>No region yet</strong>' +
+        '<span>Choose a location first.</span>' +
         '</div>';
       refreshIcons(target);
       return;
@@ -906,7 +906,7 @@
 
     var rec = recommend(data, state.resolution, state.type, state.selectedMetros);
     if (!rec) {
-      target.innerHTML = '<div class="mcc-empty-state">' + icon("radio-tower") + '<strong>No recommendation yet</strong></div>';
+      target.innerHTML = '<div class="mcc-empty-state">' + icon("radio-tower") + '<strong>No region yet</strong></div>';
       refreshIcons(target);
       return;
     }
@@ -936,7 +936,7 @@
     var resultBody = guided
       ? '<div class="mcc-guide-panel">' +
         '<ol class="mcc-guide-steps">' +
-        '<li class="mcc-guide-connect"><div><h4>Connect to the repeater CLI</h4><p>Choose USB when you can reach the repeater, or manage it over LoRa from a companion radio.</p>' +
+        '<li class="mcc-guide-connect"><div><h4>Connect to the repeater CLI</h4><p>Use USB at the repeater or remote management over LoRa.</p>' +
         '<div class="mcc-connect-methods">' +
         '<section class="mcc-connect-method"><div class="mcc-connect-method-head">' + icon("usb") + '<div><h5>USB serial</h5><small>At the repeater</small></div></div>' +
         '<ol><li>Connect the repeater to a computer with a data-capable USB cable.</li>' +
@@ -948,16 +948,16 @@
         '<li>Enter the repeater admin password, tap <strong>Log In</strong>, then open <strong>Command Line</strong>.</li></ol>' +
         '<p class="mcc-connect-note">If the repeater is missing, open Tools → Discover Nearby Nodes. If a wait timer appears, let it finish before logging in.</p></section>' +
         '</div></div></li>' +
-        '<li><div><h4>Confirm the command line</h4><p>Run this first. A version reply means the CLI is ready; make sure it matches your firmware choice.</p>' +
+        '<li><div><h4>Confirm the command line</h4><p>Run <code>ver</code> and check the version.</p>' +
         '<button type="button" class="mcc-command-line" data-cmd="ver"><span>ver</span><em>' + icon("copy") + 'Copy</em></button></div></li>' +
-        '<li><div><h4>Apply the settings</h4><p>Copy and run each line in order. Wait for the device reply before continuing.</p>' +
+        '<li><div><h4>Apply the settings</h4><p>Run each line in order. Wait for a reply.</p>' +
         '<div class="mcc-guide-command-list">' + commands.map(function (line) {
           return '<button type="button" class="mcc-command-line" data-cmd="' + esc(line) + '"><span>' + esc(line) + '</span><em>' + icon("copy") + 'Copy</em></button>';
-        }).join("") + '</div><p class="mcc-guide-stop">If a reply starts with Err, stop. Existing regions are not removed automatically.</p></div></li>' +
-        '<li><div><h4>Check, save, and verify</h4><p>Run <code>region</code>. Confirm that it follows this path:</p>' +
+        }).join("") + '</div><p class="mcc-guide-stop">Stop on <code>Err</code>. Existing regions are not cleared.</p></div></li>' +
+        '<li><div><h4>Check and save</h4><p>Run <code>region</code> and confirm:</p>' +
         '<p class="mcc-region-path"><strong>' + esc(expectedPath) + '</strong></p>' +
         '<div class="mcc-guide-command-list"><button type="button" class="mcc-command-line" data-cmd="region"><span>region</span><em>' + icon("copy") + 'Copy</em></button></div>' +
-        '<p>If the path is correct, save it:</p>' +
+        '<p>Save:</p>' +
         '<div class="mcc-guide-command-list"><button type="button" class="mcc-command-line" data-cmd="region save"><span>region save</span><em>' + icon("copy") + 'Copy</em></button></div>' +
         '<p>' + (state.includeBaseline
           ? 'Restart the device, reconnect, then run these final checks:'
@@ -1160,7 +1160,7 @@
       '<input class="mcc-input" id="mcc-location-input" type="text" autocomplete="off" spellcheck="false" placeholder="Ottawa, YOW, K1A 0B1">' +
       '<button class="mcc-button" type="button" data-action="locate">' + icon("search") + 'Find</button>' +
       '</div>' +
-      '<p class="mcc-search-privacy">Search sends your query to OpenStreetMap Nominatim / geocoder.ca. Click the map or use device location to stay fully local.</p>' +
+      '<p class="mcc-search-privacy">Search uses OpenStreetMap and geocoder.ca. Or click the map.</p>' +
       '<div data-role="status"></div>' +
       '<div class="mcc-selected-region" data-role="selected-region" hidden></div>' +
       '<details class="mcc-alternate-regions" data-role="region-browser" hidden>' +
@@ -1175,9 +1175,9 @@
       '</section>' +
       '<section class="mcc-card mcc-wizard-step" data-wizard-step="2" hidden>' +
       '<p class="mcc-step-label">Step 2 of 4</p>' +
-      '<h2>Use recommended radio settings?</h2>' +
+      '<h2>Use recommended settings?</h2>' +
       '<div class="mcc-choice-list mcc-choice-list-large" data-role="device-path" role="group" aria-label="Recommended radio settings">' +
-      '<label class="mcc-choice"><input type="radio" name="mcc-device-path" value="new" checked><span><strong>Yes — new or reset device</strong></span></label>' +
+      '<label class="mcc-choice"><input type="radio" name="mcc-device-path" value="new" checked><span><strong>Yes — apply defaults</strong></span></label>' +
       '<label class="mcc-choice"><input type="radio" name="mcc-device-path" value="existing"><span><strong>No — keep current settings</strong></span></label>' +
       '</div>' +
       '<details class="mcc-advanced-options">' +
@@ -1192,7 +1192,7 @@
       '</section>' +
       '<section class="mcc-card mcc-wizard-step" data-wizard-step="3" hidden>' +
       '<p class="mcc-step-label">Step 3 of 4</p>' +
-      '<h2>Where will it be installed?</h2>' +
+      '<h2>Installation site</h2>' +
       '<div class="mcc-choice-list" data-role="types" role="group" aria-label="Repeater installation type">' +
       '<label class="mcc-choice"><input type="radio" name="mcc-type" value="residential" checked><span><strong>Home or portable</strong></span></label>' +
       '<label class="mcc-choice"><input type="radio" name="mcc-type" value="urban"><span><strong>Rooftop or tower</strong></span></label>' +
@@ -1203,12 +1203,12 @@
       '</section>' +
       '<section class="mcc-card mcc-wizard-step" data-wizard-step="4" hidden>' +
       '<p class="mcc-step-label">Step 4 of 4</p>' +
-      '<h2>Choose how to finish</h2>' +
+      '<h2>Finish setup</h2>' +
       '<div class="mcc-finish-paths" role="group" aria-label="Choose setup instructions">' +
-      '<button type="button" class="mcc-finish-path is-active" data-finish-path="guided" aria-pressed="true">' + icon("list-checks") + '<span><strong>Guide me</strong><small>Apply the settings step by step</small></span></button>' +
-      '<button type="button" class="mcc-finish-path" data-finish-path="technical" aria-pressed="false">' + icon("terminal") + '<span><strong>Copy commands</strong><small>Show all commands at once</small></span></button>' +
+      '<button type="button" class="mcc-finish-path is-active" data-finish-path="guided" aria-pressed="true">' + icon("list-checks") + '<span><strong>Guide me</strong><small>Step-by-step help</small></span></button>' +
+      '<button type="button" class="mcc-finish-path" data-finish-path="technical" aria-pressed="false">' + icon("terminal") + '<span><strong>Copy commands</strong><small>All commands at once</small></span></button>' +
       '</div>' +
-      '<div data-role="result"><p class="mcc-result-empty">Choose a Canadian location to generate commands.</p></div>' +
+      '<div data-role="result"><p class="mcc-result-empty">Choose a location first.</p></div>' +
       '<div class="mcc-wizard-actions"><button class="mcc-button mcc-button-secondary" type="button" data-prev-step>' + icon("arrow-left") + 'Back</button><a class="mcc-button mcc-button-secondary" data-action="view-map" href="' + esc(regionPageHref("map")) + '" hidden>' + icon("map") + 'View on map</a></div>' +
       '</section>' +
       '</div>';
@@ -1305,7 +1305,7 @@
 
     function advanceStep() {
       if (state.wizardStep === 1 && !state.canGenerate) {
-        setStatus(els.status, "Choose a Canadian location before continuing.", "error");
+        setStatus(els.status, "Choose a location first.", "error");
         return;
       }
       state.maxStep = Math.max(state.maxStep, Math.min(4, state.wizardStep + 1));
@@ -1345,7 +1345,7 @@
             (nested ? leafCount + ' subregions' : child.toUpperCase() + ' · region') +
             '</small></span><span aria-hidden="true">' + (nested ? '›' : '✓') + '</span></button>';
         }).join("")
-        : '<p class="mcc-help">This is the region used for your settings.</p>';
+        : '<p class="mcc-help">Used for your settings.</p>';
     }
 
     function chooseConfigRegionNode(tag) {
@@ -1387,7 +1387,7 @@
       } else {
         state.canGenerate = true;
         state.maxStep = Math.max(state.maxStep, 2);
-        setStatus(els.status, "Region found. Confirm it below, then continue.", "info");
+        setStatus(els.status, "Region found.", "info");
         renderConfigRegionBrowser(state.resolution.primary.seed.tag);
       }
       refreshTool(data, els, state, updateMapLinks);
@@ -1400,7 +1400,7 @@
     function locate() {
       var query = els.input.value.trim();
       if (!query) {
-        setStatus(els.status, "Enter a Canadian city, airport code, or postal code.", "error");
+        setStatus(els.status, "Enter a city, airport code, or postal code.", "error");
         return;
       }
       els.locate.disabled = true;
@@ -1498,7 +1498,7 @@
       '<aside class="mcc-map-panel">' +
       '<div class="mcc-panel-header">' +
       '<h2>Find a region</h2>' +
-      '<p>Every part of Canada belongs to one local region.</p>' +
+
       '<a class="mcc-button mcc-button-secondary" href="' + esc(regionPageHref("config")) + '">' + icon("list-checks") + 'Setup</a>' +
       '</div>' +
       '<section class="mcc-card mcc-card-compact">' +
@@ -1513,12 +1513,12 @@
       '<input class="mcc-input" id="mcc-map-location-input" data-role="map-input" type="text" autocomplete="off" spellcheck="false" placeholder="Ottawa, YOW, K1A 0B1">' +
       '<button class="mcc-button" type="button" data-action="map-locate">' + icon("search") + 'Find</button>' +
       '</div>' +
-      '<p class="mcc-search-privacy">Search sends your query to OpenStreetMap Nominatim / geocoder.ca. Click the map or use device location to stay fully local.</p>' +
+      '<p class="mcc-search-privacy">Search uses OpenStreetMap and geocoder.ca. Or click the map.</p>' +
       '<div data-role="map-status"></div>' +
       '</section>' +
       '<section class="mcc-card mcc-dynamic-card" data-role="map-result-section" hidden>' +
       '<h2>Selected region</h2>' +
-      '<div data-role="map-result"><p class="mcc-result-empty">Choose a Canadian location to see its region.</p></div>' +
+      '<div data-role="map-result"><p class="mcc-result-empty">Choose a location.</p></div>' +
       '</section>' +
       '<details class="mcc-card mcc-map-options">' +
       '<summary>Settings</summary>' +
@@ -1648,7 +1648,7 @@
               '</small></span><span aria-hidden="true">' + (nested ? '›' : '✓') + '</span></button>';
           }).join("");
         } else {
-          els.children.innerHTML = '<p class="mcc-help">This is the region used for location lookup and commands.</p>';
+          els.children.innerHTML = '<p class="mcc-help">Used for lookup and commands.</p>';
         }
 
         browseLayer.clearLayers();
@@ -1707,7 +1707,7 @@
           state.canGenerate = false;
           state.detailTag = null;
           state.resolution = null;
-          setStatus(els.status, "That point appears to be outside Canada.", "warning");
+          setStatus(els.status, "Outside Canada.", "warning");
         } else {
           state.resolution = resolveLocation(data, state.lat, state.lon, state.forcedTag, state.jurisdictionTag);
           state.canGenerate = state.resolution.hasMatch;
@@ -1742,7 +1742,7 @@
         state.resolution = null;
         state.detailTag = null;
         place(state.lat, state.lon);
-        setStatus(els.status, "That point is outside the mapped Canadian regions. Choose land in Canada or search for a nearby city.", "warning");
+        setStatus(els.status, "Choose a mapped point in Canada.", "warning");
         refreshTool(data, els, state, updateBoundaryHighlight);
         if (recenter) map.setView([state.lat, state.lon], Math.max(map.getZoom(), 8));
       }
@@ -1767,7 +1767,7 @@
       function locate() {
         var query = els.input.value.trim();
         if (!query) {
-          setStatus(els.status, "Enter a Canadian city, airport code, or postal code.", "error");
+          setStatus(els.status, "Enter a city, airport code, or postal code.", "error");
           return;
         }
         els.locate.disabled = true;
@@ -1909,7 +1909,7 @@
     el.innerHTML =
       '<div class="mcc-dashboard">' +
       '<section class="mcc-console-header mcc-dashboard-header">' +
-      '<h2>Canadian regions — review map</h2>' +
+      '<h2>Canadian regions</h2>' +
       '<div class="mcc-dashboard-actions">' +
       '<a class="mcc-action-button" href="' + esc(regionPageHref("config")) + '">' + icon("list-checks") + '<span><strong>Setup</strong></span></a>' +
       '<a class="mcc-action-button" href="' + esc(regionPageHref("map")) + '">' + icon("map") + '<span><strong>Map</strong></span></a>' +

--- a/docs/config/editor/app.js
+++ b/docs/config/editor/app.js
@@ -19,7 +19,7 @@ import {
   async function fetchOk(name, options) {
     var response = await fetch(assetUrl(name), options || {});
     if (!response.ok) {
-      throw new Error("The editor data could not be loaded (" + name + ").");
+      throw new Error("Could not load editor data (" + name + ").");
     }
     return response;
   }
@@ -204,8 +204,8 @@ import {
 
   function showSubmissionResult(result, changedWhileSubmitting) {
     var prefix = document.createTextNode(changedWhileSubmitting
-      ? "Review created for the earlier submitted version: "
-      : (result.duplicate ? "This proposal was already submitted: " : "Public review created: "));
+      ? "Earlier version submitted: "
+      : (result.duplicate ? "Already submitted: " : "Review created: "));
     var link = document.createElement("a");
     link.href = result.issueUrl;
     link.target = "_blank";
@@ -491,7 +491,7 @@ import {
       return;
     }
     if (count) {
-      setValidation("Ready to validate " + count + (count === 1 ? " cell." : " cells."), "");
+      setValidation(count + (count === 1 ? " cell ready." : " cells ready."), "");
     } else {
       setValidation("", "");
     }
@@ -716,7 +716,7 @@ import {
       }
       partitionLayer.bringToBack();
       setStatus(
-        state.features.length.toLocaleString() + " editable census cells loaded.",
+        state.features.length.toLocaleString() + " census cells loaded.",
         "success"
       );
     } catch (error) {
@@ -813,7 +813,7 @@ import {
     var canonical = validatedProposal();
     if (!canonical) return;
     downloadProposal(canonical);
-    setValidation("Proposal validated locally and downloaded. Submit it for review — it is not live until merged.", "success");
+    setValidation("Proposal downloaded. It is not live until merged.", "success");
   }
 
   function resetTurnstile(message) {
@@ -824,7 +824,7 @@ import {
     }
     if (state.turnstile && state.turnstileWidgetId !== null) {
       try {
-        setAntiSpamStatus(message || "Running a new anti-spam check…", "");
+        setAntiSpamStatus(message || "Retrying check…", "");
         state.turnstile.reset(state.turnstileWidgetId);
       } catch (_error) {
         if (typeof state.turnstile.remove === "function") {
@@ -832,7 +832,7 @@ import {
         }
         state.turnstileWidgetId = null;
         elements.turnstileContainer.replaceChildren();
-        setAntiSpamStatus("The anti-spam check could not restart. Retry it below.", "error");
+        setAntiSpamStatus("Check failed. Retry.", "error");
         elements.antiSpamRetry.hidden = false;
       }
     }
@@ -852,21 +852,21 @@ import {
     return {
       onToken: function (token) {
         state.turnstileToken = String(token || "");
-        setAntiSpamStatus("Anti-spam check complete.", "success");
+        setAntiSpamStatus("Check complete.", "success");
         elements.antiSpamRetry.hidden = true;
         updateReview(false);
       },
       onError: function () {
-        setAntiSpamStatus("The anti-spam check failed. It will retry automatically.", "error");
-        scheduleTurnstileReset("Retrying the anti-spam check…", 1000);
+        setAntiSpamStatus("Check failed. Retrying…", "error");
+        scheduleTurnstileReset("Retrying check…", 1000);
       },
       onExpired: function () {
-        setAntiSpamStatus("The anti-spam check expired. Running it again…", "");
-        scheduleTurnstileReset("Running a new anti-spam check…", 250);
+        setAntiSpamStatus("Check expired. Retrying…", "");
+        scheduleTurnstileReset("Retrying check…", 250);
       },
       onTimeout: function () {
-        setAntiSpamStatus("The anti-spam check timed out. Running it again…", "error");
-        scheduleTurnstileReset("Retrying the anti-spam check…", 1000);
+        setAntiSpamStatus("Check timed out. Retrying…", "error");
+        scheduleTurnstileReset("Retrying check…", 1000);
       }
     };
   }
@@ -875,7 +875,7 @@ import {
     if (state.submissionInitialising) return;
     state.submissionInitialising = true;
     elements.antiSpamRetry.hidden = true;
-    setAntiSpamStatus("Loading anti-spam protection…", "");
+    setAntiSpamStatus("Loading check…", "");
     try {
       var endpoint = configuredSubmissionEndpoint(document);
       var config = await fetchSubmissionConfig({ endpoint: endpoint });
@@ -883,7 +883,7 @@ import {
       state.submissionConfig = config;
       state.turnstile = turnstile;
       if (state.turnstileWidgetId === null) {
-        setAntiSpamStatus("Complete the anti-spam check if prompted.", "");
+        setAntiSpamStatus("Complete the check.", "");
         state.turnstileWidgetId = renderTurnstile(
           turnstile,
           elements.turnstileContainer,
@@ -891,7 +891,7 @@ import {
           turnstileCallbacks()
         );
       } else {
-        resetTurnstile("Running a new anti-spam check…");
+        resetTurnstile("Retrying check…");
       }
     } catch (error) {
       state.submissionConfig = null;
@@ -908,7 +908,7 @@ import {
     var canonical = validatedProposal();
     if (!canonical) return;
     if (!state.submissionConfig || !state.turnstileToken || state.submitting) {
-      setValidation("Wait for the anti-spam check, then try Submit for review again.", "error");
+      setValidation("Complete the check first.", "error");
       return;
     }
     var token = state.turnstileToken;
@@ -919,7 +919,7 @@ import {
     elements.submit.setAttribute("aria-busy", "true");
     clearSubmissionResult();
     updateReview(false);
-    setValidation("Creating the public review issue…", "");
+    setValidation("Submitting…", "");
     try {
       var result = await submitRegionProposal({
         endpoint: state.submissionConfig.endpoint,
@@ -931,18 +931,18 @@ import {
       showSubmissionResult(result, changedWhileSubmitting);
       setValidation(
         changedWhileSubmitting
-          ? "The review was created, but edits made while submitting are not included. Submit again to include them."
+          ? "Submitted, but later edits were not included. Submit again to include them."
           : result.duplicate
-          ? "This proposal was already submitted. The existing review issue is linked below."
-          : "Proposal submitted. Maintainers can now review it publicly.",
+          ? "Already submitted. Open the issue below."
+          : "Submitted for review.",
         "success"
       );
     } catch (error) {
       var nextStep = error.code === "stale_base"
-        ? " Reload the editor before trying again."
+        ? " Reload and try again."
         : (error.retryable
-          ? " Your edits are still here; wait for the anti-spam check, then try again."
-          : " Download the proposal if you need to send it to a maintainer.");
+          ? " Your edits are saved here. Complete the check and try again."
+          : " Download the proposal to share it.");
       setValidation(
         (error.message || "The proposal could not be submitted.") + nextStep,
         "error"
@@ -951,13 +951,13 @@ import {
       state.submitting = false;
       elements.submit.textContent = "Submit for review";
       elements.submit.removeAttribute("aria-busy");
-      resetTurnstile("Preparing another anti-spam check…");
+      resetTurnstile("Preparing another check…");
       updateReview(false);
     }
   }
 
   async function initialise() {
-    setStatus("Loading editor data…", "");
+    setStatus("Loading editor…", "");
     try {
       state.catalog = await (await fetchOk("canada-regions.json")).json();
       await loadMembershipCsv();
@@ -976,7 +976,7 @@ import {
   }
 
   elements.province.addEventListener("change", function () {
-    if (state.proposed.size && !window.confirm("Discard this unfinished proposal and load another area?")) {
+    if (state.proposed.size && !window.confirm("Discard this draft and load another area?")) {
       elements.province.value = state.province;
       return;
     }

--- a/docs/config/editor/index.html
+++ b/docs/config/editor/index.html
@@ -27,16 +27,16 @@
   <main class="editor-layout">
     <aside class="editor-sidebar" aria-label="Boundary editing controls">
       <section class="panel intro-panel">
-        <p class="step-label">Draft only</p>
-        <h2>Adjust official census cells</h2>
-        <p class="muted compact">Validates and sends a proposed change for public review. Nothing changes until maintainers approve and merge it.</p>
+        <p class="step-label">Draft</p>
+        <h2>Adjust region boundaries</h2>
+        <p class="muted compact">Submit a boundary change for review. Nothing changes until merged.</p>
       </section>
 
       <section class="panel">
         <h2>1. Choose an area</h2>
         <label for="province-select">Province or territory</label>
         <select id="province-select"></select>
-        <p id="load-status" class="status-line" role="status" aria-live="polite">Loading editor data…</p>
+        <p id="load-status" class="status-line" role="status" aria-live="polite">Loading editor…</p>
       </section>
 
       <section class="panel">
@@ -49,7 +49,7 @@
           <button id="pan-mode" class="segment active" type="button" aria-pressed="true">Pan map</button>
           <button id="paint-mode" class="segment" type="button" aria-pressed="false">Paint cells</button>
         </div>
-        <p class="hint">Click one cell, or use Paint cells and drag across several.</p>
+        <p class="hint">Click a cell, or choose Paint and drag.</p>
       </section>
 
       <section class="panel selected-panel">
@@ -80,28 +80,28 @@
         <label for="submitted-by">Submitted by <span class="optional">optional</span></label>
         <input id="submitted-by" maxlength="80" autocomplete="name">
         <label for="reason">Reason</label>
-        <textarea id="reason" maxlength="1000" rows="3" placeholder="What local knowledge supports this change?" required></textarea>
+        <textarea id="reason" maxlength="1000" rows="3" placeholder="Why should this cell move?" required></textarea>
         <div class="submission-trap" aria-hidden="true">
           <label for="website">Website</label>
           <input id="website" name="website" tabindex="-1" autocomplete="off">
         </div>
         <div id="turnstile-container" class="turnstile-container" aria-label="Anti-spam check"></div>
-        <p id="anti-spam-status" class="anti-spam-status" role="status" aria-live="polite">Loading anti-spam protection…</p>
-        <button id="anti-spam-retry" class="inline-retry" type="button" hidden>Retry anti-spam check</button>
+        <p id="anti-spam-status" class="anti-spam-status" role="status" aria-live="polite">Loading check…</p>
+        <button id="anti-spam-retry" class="inline-retry" type="button" hidden>Retry check</button>
         <div id="validation-message" class="validation-message" role="status" aria-live="polite"></div>
         <div id="submission-result" class="submission-result" role="status" aria-live="polite"></div>
         <div class="proposal-actions">
           <button id="submit-button" class="button primary full" type="button" disabled>Submit for review</button>
           <button id="export-button" class="button secondary full" type="button" disabled>Download proposal</button>
         </div>
-        <p class="hint">No account is needed. The proposal is checked for spam, then a public review issue is created automatically.</p>
+        <p class="hint">No account needed. Changes require review.</p>
       </section>
     </aside>
 
     <section class="map-shell" aria-label="Region map editor">
       <div class="map-toolbar">
         <span id="map-heading">Canada</span>
-        <span class="map-help">Official census cells · yellow outline means changed</span>
+        <span class="map-help">Census cells · yellow means changed</span>
       </div>
       <div id="editor-map" role="application" aria-label="Interactive region boundary map"></div>
       <div class="map-legend" aria-hidden="true">

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -6,10 +6,10 @@ hide:
 ---
 # Set up repeater regions
 
-Find the right region for a repeater, then get step-by-step help or commands to copy. Every Canadian location belongs to one region, so choose a province or larger region to see its subregions.
+Find your repeater region and settings.
 
 <div data-mcc-regions="config" data-mcc-root="./"></div>
 
-<noscript>This setup guide needs JavaScript. You can still read the [region strategy discussion](https://forum.meshcore.ca/t/thoughts-canadian-regions-strategy/54).</noscript>
+<noscript>JavaScript is required. [Read the region standard](standard.md).</noscript>
 
-<small>See the [region standard](standard.md) for definitions and authority. [MeshMapper](https://meshmapper.net/) and community feedback helped shape the boundaries. [Region data sources and licences](../assets/regions/NOTICE.txt), or [share feedback](https://forum.meshcore.ca/t/thoughts-canadian-regions-strategy/54/46).</small>
+<small>[Region standard](standard.md) · [Data sources](../assets/regions/NOTICE.txt) · [Share feedback](https://forum.meshcore.ca/t/thoughts-canadian-regions-strategy/54/46)</small>

--- a/docs/config/map.md
+++ b/docs/config/map.md
@@ -6,10 +6,10 @@ hide:
 
 # Canadian region map
 
-Search for a location or choose a larger region to reveal its subregions.
+Search or browse Canadian regions.
 
 <div data-mcc-regions="map" data-mcc-root="../"></div>
 
-<noscript>The interactive map needs JavaScript. You can still review the [region strategy discussion](https://forum.meshcore.ca/t/thoughts-canadian-regions-strategy/54).</noscript>
+<noscript>JavaScript is required. [Read the region standard](standard.md).</noscript>
 
-<small>The map uses one Canada-wide layer with no overlapping regions. [MeshMapper](https://meshmapper.net/) and community feedback helped shape it. See the [region standard](standard.md) and [data sources](../assets/regions/NOTICE.txt).</small>
+<small>[Region standard](standard.md) · [Data sources](../assets/regions/NOTICE.txt)</small>

--- a/docs/javascripts/community-submission.js
+++ b/docs/javascripts/community-submission.js
@@ -70,14 +70,14 @@ export function buildCommunityIdea(data) {
     category,
     experience,
     summary: boundedText(data.summary, 100, "Short title", true),
-    need: boundedText(data.need, 2000, "What is difficult today", true, true),
-    idea: boundedText(data.idea, 2000, "What would make it better", true, true),
+    need: boundedText(data.need, 2000, "What is difficult now", true, true),
+    idea: boundedText(data.idea, 2000, "What would help", true, true),
     publicAcknowledged: true
   };
   const optional = {
     region: boundedText(data.region, 100, "City or broad region"),
     context: boundedText(data.context, 2000, "Additional context", false, true),
-    followUp: boundedText(data.followUp, 120, "Public follow-up contact")
+    followUp: boundedText(data.followUp, 120, "Public contact")
   };
   Object.entries(optional).forEach(([key, value]) => {
     if (value) proposal[key] = value;
@@ -95,15 +95,15 @@ export function buildSubmissionText(proposal) {
     section("Contribution type", proposal.category),
     section("MeshCore experience", proposal.experience),
     section("City or broad region", proposal.region),
-    section("What I am trying to do / what is difficult", proposal.need),
-    section("What would make it better", proposal.idea),
+    section("Problem", proposal.need),
+    section("Suggested change", proposal.idea),
     section("Additional context", proposal.context),
     section(
-      "Public follow-up contact",
+      "Public contact",
       proposal.followUp,
       "Please reply in the submission thread."
     ),
-    "---\n\n_Prepared with the MeshCore Canada community submission helper._"
+    "---\n\n_Prepared on meshcore.ca._"
   ].join("\n\n");
 }
 

--- a/docs/javascripts/community-submission.js
+++ b/docs/javascripts/community-submission.js
@@ -3,6 +3,7 @@ export const COMMUNITY_SUBMISSION_ENDPOINT =
   "https://api.meshcore.ca:21323/api/meshcore-canada/submissions";
 export const COMMUNITY_ISSUE_ENDPOINT =
   "https://github.com/MeshCore-ca/MeshCore-Canada/issues/new";
+export const COMMUNITY_SOURCE_PAGE = "https://meshcore.ca/submit-idea/";
 export const MAX_GITHUB_URL_LENGTH = 7000;
 
 export const COMMUNITY_CATEGORIES = Object.freeze([
@@ -117,7 +118,8 @@ export function buildManualGithubLink(proposal) {
     need: proposal.need,
     idea: proposal.idea,
     context: proposal.context || "",
-    follow_up: proposal.followUp || ""
+    follow_up: proposal.followUp || "",
+    source_page: COMMUNITY_SOURCE_PAGE
   });
   const url = `${COMMUNITY_ISSUE_ENDPOINT}?${params.toString()}`;
   if (url.length <= MAX_GITHUB_URL_LENGTH) {
@@ -125,7 +127,8 @@ export function buildManualGithubLink(proposal) {
   }
   const fallback = new URLSearchParams({
     template: "community_idea.yml",
-    title: `[Community idea] ${proposal.summary}`
+    title: `[Community idea] ${proposal.summary}`,
+    source_page: COMMUNITY_SOURCE_PAGE
   });
   return Object.freeze({
     url: `${COMMUNITY_ISSUE_ENDPOINT}?${fallback.toString()}`,

--- a/docs/javascripts/submission-form.js
+++ b/docs/javascripts/submission-form.js
@@ -73,10 +73,10 @@
 
   function showResult(value, changedWhileSubmitting) {
     const prefix = changedWhileSubmitting
-      ? "The submitted version has a public review issue. Newer changes are not included. "
+      ? "Earlier version submitted. New changes are not included. "
       : value.duplicate
-        ? "This idea was already submitted. "
-        : "Your idea now has a public review issue. ";
+        ? "Already submitted. "
+        : "Submitted for review. ";
     const link = document.createElement("a");
     link.href = value.issueUrl;
     link.target = "_blank";
@@ -116,7 +116,7 @@
     elements.preview.hidden = true;
     clearGithubNote();
     clearResult();
-    if (!submitting) elements.status.textContent = "Review the updated answers before submitting.";
+    if (!submitting) elements.status.textContent = "Answers changed. Review again.";
     updateActions();
   }
 
@@ -154,7 +154,7 @@
     }
     if (turnstile && widgetId !== null) {
       try {
-        setAntiSpamStatus(message || "Running a new anti-spam check…");
+        setAntiSpamStatus(message || "Retrying check…");
         turnstile.reset(widgetId);
       } catch (_error) {
         if (typeof turnstile.remove === "function") {
@@ -162,7 +162,7 @@
         }
         widgetId = null;
         elements.turnstile.replaceChildren();
-        setAntiSpamStatus("The anti-spam check could not restart. Retry it below.", "error");
+        setAntiSpamStatus("Check failed. Retry.", "error");
         elements.antiSpamRetry.hidden = false;
       }
     }
@@ -180,20 +180,20 @@
     return {
       onToken(value) {
         token = String(value || "");
-        setAntiSpamStatus("Anti-spam check complete.", "success");
+        setAntiSpamStatus("Check complete.", "success");
         elements.antiSpamRetry.hidden = true;
         updateActions();
       },
       onError() {
-        setAntiSpamStatus("The anti-spam check failed. It will retry automatically.", "error");
+        setAntiSpamStatus("Check failed. Retrying…", "error");
         scheduleReset("Retrying the anti-spam check…", 1000);
       },
       onExpired() {
-        setAntiSpamStatus("The anti-spam check expired. Running it again…");
-        scheduleReset("Running a new anti-spam check…", 250);
+        setAntiSpamStatus("Check expired. Retrying…");
+        scheduleReset("Retrying check…", 250);
       },
       onTimeout() {
-        setAntiSpamStatus("The anti-spam check timed out. Running it again…", "error");
+        setAntiSpamStatus("Check timed out. Retrying…", "error");
         scheduleReset("Retrying the anti-spam check…", 1000);
       }
     };
@@ -203,7 +203,7 @@
     if (initialising) return;
     initialising = true;
     elements.antiSpamRetry.hidden = true;
-    setAntiSpamStatus("Loading anti-spam protection…");
+    setAntiSpamStatus("Loading check…");
     try {
       const loaded = await loadModules();
       config = await loaded.transport.fetchSubmissionConfig({
@@ -211,7 +211,7 @@
       });
       turnstile = await loaded.transport.loadTurnstile();
       if (widgetId === null) {
-        setAntiSpamStatus("Complete the anti-spam check to submit.");
+        setAntiSpamStatus("Complete the check.");
         widgetId = loaded.transport.renderTurnstile(
           turnstile,
           elements.turnstile,
@@ -219,13 +219,13 @@
           callbacks()
         );
       } else {
-        resetTurnstile("Running a new anti-spam check…");
+        resetTurnstile("Retrying check…");
       }
     } catch (_error) {
       config = null;
       token = "";
       setAntiSpamStatus(
-        "Anonymous submission is unavailable right now. You can still copy the idea or use GitHub.",
+        "Anonymous submission is unavailable. Copy the idea or use GitHub.",
         "error"
       );
       elements.antiSpamRetry.hidden = false;
@@ -254,14 +254,14 @@
       if (manual.fullyPrefilled) {
         clearGithubNote();
       } else {
-        elements.githubNote.textContent = "This idea is too long for a reliable GitHub prefill. Copy the prepared text before using the manual GitHub option.";
+        elements.githubNote.textContent = "Too long to prefill. Copy the text, then use GitHub.";
         elements.githubNote.hidden = false;
       }
       updateActions();
       if (!config || !token) void initialiseSubmission();
       elements.status.textContent = config && token
-        ? "Preview ready. Submit it below or choose another route."
-        : "Preview ready. You can copy it now while anonymous submission is checked.";
+        ? "Ready to submit."
+        : "Preview ready.";
       const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
       elements.preview.scrollIntoView({ behavior: reducedMotion ? "auto" : "smooth", block: "nearest" });
     } catch (error) {
@@ -279,20 +279,20 @@
     if (!preparedText || preparedRevision !== revision) return;
     try {
       await copyText(preparedText);
-      elements.status.textContent = "Copied. You can paste the idea into the forum or Discord.";
+      elements.status.textContent = "Copied.";
     } catch (_error) {
       selectPreviewText();
-      elements.status.textContent = "Copy was blocked by the browser. The preview is selected; copy it manually.";
+      elements.status.textContent = "Copy blocked. Copy the selected preview.";
     }
   });
 
   elements.submit.addEventListener("click", async () => {
     if (!preparedProposal || preparedRevision !== revision) {
-      elements.status.textContent = "Review the current answers before submitting.";
+      elements.status.textContent = "Review the latest answers.";
       return;
     }
     if (!config || !token || submitting) {
-      elements.status.textContent = "Wait for the anti-spam check, then try Submit idea again.";
+      elements.status.textContent = "Complete the check first.";
       return;
     }
     const loaded = await loadModules();
@@ -305,7 +305,7 @@
     elements.submit.setAttribute("aria-busy", "true");
     clearResult();
     updateActions();
-    elements.status.textContent = "Creating the public review issue…";
+    elements.status.textContent = "Submitting…";
     try {
       const value = await loaded.transport.submitSubmission({
         endpoint: config.endpoint,
@@ -318,18 +318,18 @@
       elements.status.textContent = changed
         ? "The reviewed version was submitted. Review and submit again to include your newer changes."
         : value.duplicate
-          ? "This idea already has a review issue."
-          : "Idea submitted. Maintainers can now review it publicly.";
+          ? "Already submitted."
+          : "Submitted for review.";
     } catch (error) {
       const nextStep = error.retryable
-        ? " Your answers are still here. Wait for the anti-spam check, then try again."
-        : " Copy the prepared text or use the manual GitHub option if you need another route.";
+        ? " Your answers are saved here. Complete the check and try again."
+        : " Copy the text or use GitHub.";
       elements.status.textContent = (error.message || "The idea could not be submitted.") + nextStep;
     } finally {
       submitting = false;
       elements.submit.textContent = "Submit idea";
       elements.submit.removeAttribute("aria-busy");
-      resetTurnstile("Preparing another anti-spam check…");
+      resetTurnstile("Preparing another check…");
       updateActions();
     }
   });
@@ -337,7 +337,7 @@
   elements.github.addEventListener("click", (event) => {
     if (elements.github.getAttribute("aria-disabled") === "true") {
       event.preventDefault();
-      elements.status.textContent = "Review the submission before opening the manual GitHub form.";
+      elements.status.textContent = "Review the idea first.";
     }
   });
 

--- a/docs/javascripts/submission-form.js
+++ b/docs/javascripts/submission-form.js
@@ -12,11 +12,14 @@
   const elements = {
     preview: document.getElementById("submission-preview"),
     status: document.getElementById("submission-status"),
+    review: document.getElementById("review-submission"),
     copy: document.getElementById("copy-submission"),
     submit: document.getElementById("submit-community-idea"),
     github: document.getElementById("open-github-submission"),
     githubNote: document.getElementById("submission-github-note"),
     result: document.getElementById("submission-result"),
+    verification: document.getElementById("submission-verification"),
+    finalActions: document.getElementById("submission-final-actions"),
     turnstile: document.getElementById("submission-turnstile"),
     antiSpamStatus: document.getElementById("submission-anti-spam-status"),
     antiSpamRetry: document.getElementById("submission-anti-spam-retry"),
@@ -49,6 +52,11 @@
 
   function updateActions() {
     const current = preparedProposal && preparedRevision === revision;
+    form.dataset.prepared = current ? "true" : "false";
+    elements.review.textContent = current ? "Update preview" : "Review idea";
+    elements.review.classList.toggle("md-button--primary", !current);
+    elements.verification.hidden = !current;
+    elements.finalActions.hidden = !current;
     elements.submit.disabled = !current || !config || !token || submitting;
     elements.copy.disabled = !current || submitting;
   }
@@ -203,7 +211,7 @@
       });
       turnstile = await loaded.transport.loadTurnstile();
       if (widgetId === null) {
-        setAntiSpamStatus("Complete the anti-spam check if prompted.");
+        setAntiSpamStatus("Complete the anti-spam check to submit.");
         widgetId = loaded.transport.renderTurnstile(
           turnstile,
           elements.turnstile,
@@ -213,11 +221,11 @@
       } else {
         resetTurnstile("Running a new anti-spam check…");
       }
-    } catch (error) {
+    } catch (_error) {
       config = null;
       token = "";
       setAntiSpamStatus(
-        error.message || "Anti-spam protection is unavailable. Copy the idea or use the manual GitHub option.",
+        "Anonymous submission is unavailable right now. You can still copy the idea or use GitHub.",
         "error"
       );
       elements.antiSpamRetry.hidden = false;
@@ -249,10 +257,11 @@
         elements.githubNote.textContent = "This idea is too long for a reliable GitHub prefill. Copy the prepared text before using the manual GitHub option.";
         elements.githubNote.hidden = false;
       }
-      elements.status.textContent = config && token
-        ? "Review the text below, then submit it. No GitHub account is needed."
-        : "Idea prepared. You can copy it now; anonymous submission will be available when the anti-spam check completes.";
       updateActions();
+      if (!config || !token) void initialiseSubmission();
+      elements.status.textContent = config && token
+        ? "Preview ready. Submit it below or choose another route."
+        : "Preview ready. You can copy it now while anonymous submission is checked.";
       const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
       elements.preview.scrollIntoView({ behavior: reducedMotion ? "auto" : "smooth", block: "nearest" });
     } catch (error) {
@@ -333,5 +342,5 @@
   });
 
   elements.antiSpamRetry.addEventListener("click", initialiseSubmission);
-  initialiseSubmission();
+  updateActions();
 })();

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,46 +1,63 @@
 /* Home page community links use the built-in grid cards styling. */
 
-.submission-hero {
-  margin: 1rem 0 1.5rem;
-  padding: clamp(1.25rem, 4vw, 2.2rem);
-  border: 1px solid var(--md-accent-fg-color);
-  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 42%, transparent);
-  border-radius: 1rem;
-  background: var(--md-default-bg-color);
-  background:
-    radial-gradient(circle at top right, color-mix(in srgb, var(--md-accent-fg-color) 24%, transparent), transparent 42%),
-    linear-gradient(145deg, color-mix(in srgb, var(--md-primary-fg-color) 22%, transparent), transparent 72%);
+:root {
+  --submission-error-color: #b42318;
+  --submission-error-bg: rgb(180 35 24 / 8%);
 }
 
-.submission-hero__eyebrow {
-  margin: 0 0 0.35rem;
-  color: var(--md-accent-fg-color);
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
+[data-md-color-scheme="slate"] {
+  --submission-error-color: #ffb4ab;
+  --submission-error-bg: rgb(255 180 171 / 8%);
 }
 
-.submission-hero h2 {
-  margin: 0 0 0.6rem;
-  font-weight: 700;
-}
-
-.submission-hero p:last-child {
-  margin-bottom: 0;
+.submission-intro {
   max-width: 48rem;
+  margin: 0 0 1.5rem;
+}
+
+.submission-intro > p:first-child {
+  margin-top: 0;
+  font-size: 1.02rem;
+  line-height: 1.65;
+}
+
+.submission-privacy {
+  margin: 1rem 0 0;
+  padding: 0.75rem 0.9rem;
+  border-left: 3px solid var(--md-default-fg-color--lighter);
+  background: var(--md-code-bg-color);
+  color: var(--md-default-fg-color--light);
+  font-size: 0.82rem;
+}
+
+.submission-privacy strong {
+  color: var(--md-default-fg-color);
 }
 
 .submission-form {
   display: grid;
-  gap: 1.15rem;
+  gap: 1.2rem;
   margin: 1.5rem 0;
-  padding: clamp(1rem, 3vw, 1.6rem);
+  padding: clamp(1rem, 2.5vw, 1.5rem);
   border: 1px solid var(--md-default-fg-color--lightest);
-  border-radius: 0.8rem;
+  border-radius: 0.55rem;
   background: var(--md-default-bg-color);
-  background: color-mix(in srgb, var(--md-default-bg-color) 94%, var(--md-primary-fg-color));
-  box-shadow: 0 0.35rem 1.25rem rgb(0 0 0 / 12%);
+}
+
+.submission-form__header {
+  padding-bottom: 0.2rem;
+}
+
+.submission-form__header h2 {
+  margin: 0 0 0.25rem;
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.submission-form__header p {
+  margin: 0;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.82rem;
 }
 
 .submission-form__grid {
@@ -51,27 +68,22 @@
 
 .submission-field {
   display: grid;
-  gap: 0.35rem;
+  align-content: start;
+  gap: 0.4rem;
 }
 
 .submission-field label,
 .submission-form legend {
   color: var(--md-default-fg-color);
+  font-size: 0.84rem;
   font-weight: 650;
-}
-
-.submission-field__hint {
-  color: var(--md-default-fg-color--light);
-  font-size: 0.78rem;
-  line-height: 1.45;
 }
 
 .submission-no-script,
 .submission-github-note {
   margin: 0;
-  padding: 0.8rem 0.9rem;
-  border-left: 0.2rem solid var(--md-accent-fg-color);
-  border-radius: 0.25rem;
+  padding: 0.75rem 0.9rem;
+  border-left: 3px solid var(--md-accent-fg-color);
   background: var(--md-code-bg-color);
   color: var(--md-default-fg-color);
   font-size: 0.82rem;
@@ -83,25 +95,69 @@
   box-sizing: border-box;
   width: 100%;
   border: 1px solid var(--md-default-fg-color--lighter);
-  border-radius: 0.45rem;
-  padding: 0.7rem 0.8rem;
+  border-radius: 0.4rem;
+  padding: 0.65rem 0.75rem;
   background: var(--md-default-bg-color);
   color: var(--md-default-fg-color);
   font: inherit;
 }
 
+.submission-form input,
+.submission-form select {
+  min-height: 2.65rem;
+}
+
 .submission-form textarea {
-  min-height: 7.5rem;
+  min-height: 6rem;
+  line-height: 1.5;
   resize: vertical;
+}
+
+.submission-form__grid--ideas textarea {
+  min-height: 9rem;
+}
+
+.submission-form input::placeholder,
+.submission-form textarea::placeholder {
+  color: var(--md-default-fg-color--lighter);
+  opacity: 1;
 }
 
 .submission-form input:focus-visible,
 .submission-form select:focus-visible,
 .submission-form textarea:focus-visible,
 .submission-form button:focus-visible,
-.submission-form a:focus-visible {
-  outline: 0.16rem solid var(--md-accent-fg-color);
-  outline-offset: 0.12rem;
+.submission-form a:focus-visible,
+.submission-optional summary:focus-visible,
+.submission-alternatives summary:focus-visible {
+  outline: 2px solid var(--md-accent-fg-color);
+  outline-offset: 2px;
+}
+
+.submission-optional {
+  padding: 0.85rem 0;
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.submission-optional summary,
+.submission-alternatives summary {
+  cursor: pointer;
+  color: var(--md-default-fg-color);
+  font-weight: 700;
+}
+
+.submission-optional summary span {
+  margin-left: 0.35rem;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.submission-optional__body {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
 }
 
 .submission-consent {
@@ -109,37 +165,17 @@
   grid-template-columns: auto 1fr;
   align-items: start;
   gap: 0.65rem;
-  padding: 0.85rem;
-  border-radius: 0.5rem;
+  padding: 0.8rem 0.9rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.4rem;
   background: var(--md-code-bg-color);
-  background: color-mix(in srgb, var(--md-accent-fg-color) 9%, transparent);
+  font-size: 0.84rem;
 }
 
 .submission-consent input {
   width: auto;
+  min-height: auto;
   margin-top: 0.2rem;
-}
-
-.submission-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-  align-items: center;
-}
-
-.submission-actions .md-button {
-  margin: 0;
-}
-
-.submission-actions button {
-  cursor: pointer;
-}
-
-.submission-actions button:disabled,
-.submission-actions .is-disabled {
-  cursor: not-allowed;
-  opacity: 0.48;
-  pointer-events: none;
 }
 
 .submission-trap {
@@ -152,22 +188,65 @@
   pointer-events: none;
 }
 
+.submission-review-action {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.submission-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.submission-review-action .md-button,
+.submission-actions .md-button {
+  margin: 0;
+}
+
+.submission-actions button,
+.submission-review-action button {
+  cursor: pointer;
+}
+
+.submission-actions button:disabled,
+.submission-actions .is-disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+  pointer-events: none;
+}
+
+.submission-form [hidden],
+.submission-alternatives[hidden] {
+  display: none !important;
+}
+
 .submission-verification {
   display: grid;
-  gap: 0.4rem;
+  gap: 0.45rem;
   justify-items: start;
+  padding-top: 0.2rem;
 }
 
 .submission-turnstile {
-  min-height: 2.25rem;
+  min-height: 0;
 }
 
 .submission-anti-spam-status,
+.submission-status,
 .submission-result {
-  min-height: 1.25rem;
   margin: 0;
   color: var(--md-default-fg-color--light);
   font-size: 0.8rem;
+}
+
+.submission-status:empty,
+.submission-anti-spam-status:empty,
+.submission-result:empty {
+  display: none;
 }
 
 .submission-anti-spam-status[data-state="success"],
@@ -176,19 +255,20 @@
 }
 
 .submission-anti-spam-status[data-state="error"] {
-  color: var(--md-code-hl-string-color);
+  padding: 0.55rem 0.7rem;
+  border-left: 3px solid var(--submission-error-color);
+  background: var(--submission-error-bg);
+  color: var(--submission-error-color);
 }
 
 .submission-inline-retry {
-  margin: 0;
   padding: 0.35rem 0.65rem;
   font-size: 0.75rem;
 }
 
 .submission-result:not(:empty) {
-  padding: 0.8rem 0.9rem;
-  border-left: 0.2rem solid var(--md-accent-fg-color);
-  border-radius: 0.25rem;
+  padding: 0.75rem 0.9rem;
+  border-left: 3px solid var(--md-accent-fg-color);
   background: var(--md-code-bg-color);
 }
 
@@ -196,46 +276,64 @@
   font-weight: 700;
 }
 
-.submission-status {
-  min-height: 1.25rem;
-  margin: 0;
-  color: var(--md-default-fg-color--light);
-  font-size: 0.8rem;
-}
-
 .submission-preview {
-  margin-top: 0.25rem;
-  padding: 1rem;
-  overflow-x: auto;
+  max-height: 22rem;
+  margin: 0;
+  padding: 0.9rem;
+  overflow: auto;
   border: 1px solid var(--md-default-fg-color--lightest);
-  border-radius: 0.5rem;
+  border-radius: 0.4rem;
   background: var(--md-code-bg-color);
+  font-size: 0.78rem;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
 
-.submission-routes {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.85rem;
-  margin: 1.2rem 0;
-  padding: 0;
-  list-style: none;
+.submission-alternatives {
+  margin: 1.25rem 0 2rem;
+  padding: 0.8rem 0;
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
 }
 
-.submission-route {
-  padding: 1rem;
-  border: 1px solid var(--md-default-fg-color--lightest);
-  border-radius: 0.65rem;
+.submission-alternatives p {
+  margin: 0.75rem 0 0;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.84rem;
 }
 
-.submission-route h3 {
-  margin-top: 0;
+@media screen and (max-width: 52em) {
+  .submission-form__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .submission-form__grid--ideas textarea {
+    min-height: 7.5rem;
+  }
 }
 
 @media screen and (max-width: 44.9844em) {
-  .submission-form__grid,
-  .submission-routes {
+  .submission-form {
+    gap: 1rem;
+    padding: 1rem;
+  }
+
+  .submission-review-action {
+    align-items: stretch;
+  }
+
+  .submission-review-action .md-button {
+    width: 100%;
+    text-align: center;
+  }
+
+  .submission-actions {
+    display: grid;
     grid-template-columns: 1fr;
+  }
+
+  .submission-actions .md-button {
+    width: 100%;
+    text-align: center;
   }
 }

--- a/docs/submit-idea.md
+++ b/docs/submit-idea.md
@@ -2,35 +2,30 @@
 hide:
   - toc
 ---
-# Share an Idea
+# Share an idea
 
-<div class="submission-hero">
-  <p class="submission-hero__eyebrow">Community submission helper</p>
-  <h2>Your experience is useful—even if you are brand new</h2>
-  <p>Describe the problem in your own words. You do not need to know GitHub, write code, understand radio settings, or have a finished solution. The helper below turns what you know into a clear submission for the MeshCore Canada maintainers.</p>
+<div class="submission-intro">
+  <p>Tell us what is missing, confusing, or difficult. We will turn your answers into a public issue for the MeshCore Canada maintainers. <strong>No GitHub account is needed.</strong></p>
+  <p class="submission-privacy"><strong>Keep it public.</strong> Do not include passwords, private keys, API tokens, exact home addresses, or private coordinates. A city or broad region is enough.</p>
 </div>
-
-!!! info "No GitHub account is needed"
-    Review the prepared text, complete the anti-spam check if prompted, and select **Submit idea**. The helper creates a public review issue automatically.
-
-!!! warning "Submissions are public"
-    Do not include passwords, private channel keys, API tokens, exact home addresses, private coordinates, or anything else you would not post publicly. A city or broad region is enough.
-
-## Tell us what would help
 
 <form id="community-submission-form" class="submission-form" action="https://github.com/MeshCore-ca/MeshCore-Canada/issues/new" method="get" target="_blank" rel="noopener">
   <input type="hidden" name="template" value="community_idea.yml">
   <noscript>
     <div class="submission-no-script" role="note">
-      <strong>JavaScript is turned off.</strong> Anonymous submission and the preview require JavaScript. This form will instead open the guided GitHub form, which requires a GitHub account. You can also copy your answers into the forum or Discord.
+      <strong>JavaScript is turned off.</strong> This form will open the guided GitHub form instead, which requires a GitHub account.
     </div>
   </noscript>
 
+  <div class="submission-form__header">
+    <h2>Describe your idea</h2>
+    <p>Five short fields are required. You can add more context if it is useful.</p>
+  </div>
+
   <div class="submission-form__grid">
     <div class="submission-field">
-      <label for="submission-category">What kind of contribution is this?</label>
-      <span id="submission-category-hint" class="submission-field__hint">Choose the closest match. Maintainers can adjust it later.</span>
-      <select id="submission-category" name="category" aria-describedby="submission-category-hint" required>
+      <label for="submission-category">Type of idea</label>
+      <select id="submission-category" name="category" required>
         <option value="">Choose the closest match</option>
         <option>Newcomer or accessibility improvement</option>
         <option>Documentation correction</option>
@@ -43,9 +38,8 @@ hide:
     </div>
 
     <div class="submission-field">
-      <label for="submission-experience">How familiar are you with MeshCore?</label>
-      <span id="submission-experience-hint" class="submission-field__hint">This helps maintainers explain the next step at a useful level.</span>
-      <select id="submission-experience" name="experience" aria-describedby="submission-experience-hint" required>
+      <label for="submission-experience">Your MeshCore experience</label>
+      <select id="submission-experience" name="experience" required>
         <option value="">Choose one</option>
         <option>Brand new / researching</option>
         <option>Setting up my first node</option>
@@ -58,43 +52,46 @@ hide:
 
   <div class="submission-field">
     <label for="submission-summary">Short title</label>
-    <span id="submission-summary-hint" class="submission-field__hint">One sentence is enough. Example: “A printable checklist for first-time repeater installs.”</span>
-    <input id="submission-summary" name="summary" type="text" maxlength="100" autocomplete="off" aria-describedby="submission-summary-hint" required>
+    <input id="submission-summary" name="summary" type="text" maxlength="100" autocomplete="off" placeholder="Example: Add a first-time repeater checklist" required>
   </div>
 
-  <div class="submission-field">
-    <label for="submission-region">City or broad region <span class="submission-field__hint">(optional)</span></label>
-    <span id="submission-region-hint" class="submission-field__hint">This helps when the idea depends on local coverage or community information. Do not post a home address.</span>
-    <input id="submission-region" name="region" type="text" maxlength="100" autocomplete="address-level2" aria-describedby="submission-region-hint" placeholder="Example: Waterloo Region, Ontario">
+  <div class="submission-form__grid submission-form__grid--ideas">
+    <div class="submission-field">
+      <label for="submission-need">What is difficult now?</label>
+      <textarea id="submission-need" name="need" maxlength="2000" rows="5" placeholder="What were you trying to do, and where did you get stuck?" required></textarea>
+    </div>
+
+    <div class="submission-field">
+      <label for="submission-idea">What would help?</label>
+      <textarea id="submission-idea" name="idea" maxlength="2000" rows="5" placeholder="Describe the improvement you would like." required></textarea>
+    </div>
   </div>
 
-  <div class="submission-field">
-    <label for="submission-need">What are you trying to do, or what is difficult today?</label>
-    <span id="submission-need-hint" class="submission-field__hint">Plain language is best. Tell us where you got stuck, what was missing, or what you observed.</span>
-    <textarea id="submission-need" name="need" maxlength="2000" aria-describedby="submission-need-hint" required></textarea>
-  </div>
+  <details class="submission-optional">
+    <summary>Add context <span>Optional</span></summary>
+    <div class="submission-optional__body">
+      <div class="submission-form__grid">
+        <div class="submission-field">
+          <label for="submission-region">City or broad region</label>
+          <input id="submission-region" name="region" type="text" maxlength="100" autocomplete="address-level2" placeholder="Example: Waterloo Region, Ontario">
+        </div>
 
-  <div class="submission-field">
-    <label for="submission-idea">What would make it better?</label>
-    <span id="submission-idea-hint" class="submission-field__hint">A rough idea is welcome. You do not need to design the complete solution.</span>
-    <textarea id="submission-idea" name="idea" maxlength="2000" aria-describedby="submission-idea-hint" required></textarea>
-  </div>
+        <div class="submission-field">
+          <label for="submission-follow-up">Public username for follow-up</label>
+          <input id="submission-follow-up" name="follow_up" type="text" maxlength="120" autocomplete="off" placeholder="Example: @meshfriend on Discord">
+        </div>
+      </div>
 
-  <div class="submission-field">
-    <label for="submission-context">Anything else that might help? <span class="submission-field__hint">(optional)</span></label>
-    <span id="submission-context-hint" class="submission-field__hint">Examples: device model, app, screenshot description, related page, what you already tried, or who else this may help.</span>
-    <textarea id="submission-context" name="context" maxlength="2000" aria-describedby="submission-context-hint"></textarea>
-  </div>
-
-  <div class="submission-field">
-    <label for="submission-follow-up">Public username or profile for follow-up <span class="submission-field__hint">(optional)</span></label>
-    <span id="submission-follow-up-hint" class="submission-field__hint">A Discord username, forum profile, or GitHub username is enough. Avoid email addresses or other private contact information.</span>
-    <input id="submission-follow-up" name="follow_up" type="text" maxlength="120" autocomplete="off" aria-describedby="submission-follow-up-hint" placeholder="Example: @meshfriend on Discord">
-  </div>
+      <div class="submission-field">
+        <label for="submission-context">Anything else?</label>
+        <textarea id="submission-context" name="context" maxlength="2000" rows="4" placeholder="Device, app, related page, what you tried, or who else this may help."></textarea>
+      </div>
+    </div>
+  </details>
 
   <label class="submission-consent" for="submission-public">
     <input id="submission-public" name="public" type="checkbox" required>
-    <span>I understand this submission will be public and does not contain secrets or precise private location information.</span>
+    <span>I understand this will be public and contains no secrets or exact private locations.</span>
   </label>
 
   <div class="submission-trap" aria-hidden="true">
@@ -102,44 +99,34 @@ hide:
     <input id="submission-website" type="text" maxlength="200" tabindex="-1" autocomplete="off">
   </div>
 
-  <div class="submission-verification">
-    <div id="submission-turnstile" class="submission-turnstile" aria-label="Anti-spam check"></div>
-    <p id="submission-anti-spam-status" class="submission-anti-spam-status" role="status" aria-live="polite">Loading anti-spam protection…</p>
-    <button id="submission-anti-spam-retry" class="md-button submission-inline-retry" type="button" hidden>Retry anti-spam check</button>
+  <div class="submission-review-action">
+    <button id="review-submission" class="md-button md-button--primary" type="submit">Review idea</button>
+    <p id="submission-status" class="submission-status" role="status" aria-live="polite"></p>
   </div>
 
-  <div class="submission-actions">
-    <button class="md-button" type="submit">Review submission</button>
-    <button id="copy-submission" class="md-button" type="button" disabled>Copy text</button>
+  <pre id="submission-preview" class="submission-preview" tabindex="-1" hidden aria-label="Prepared submission preview"></pre>
+
+  <div id="submission-verification" class="submission-verification" hidden>
+    <div id="submission-turnstile" class="submission-turnstile" aria-label="Anti-spam check"></div>
+    <p id="submission-anti-spam-status" class="submission-anti-spam-status" role="status" aria-live="polite"></p>
+    <button id="submission-anti-spam-retry" class="md-button submission-inline-retry" type="button" hidden>Retry check</button>
+  </div>
+
+  <div id="submission-final-actions" class="submission-actions" hidden>
     <button id="submit-community-idea" class="md-button md-button--primary" type="button" disabled>Submit idea</button>
-    <a id="open-github-submission" class="md-button is-disabled" href="#" aria-disabled="true" target="_blank" rel="noopener">Open on GitHub manually</a>
+    <button id="copy-submission" class="md-button" type="button" disabled>Copy text</button>
+    <a id="open-github-submission" class="md-button is-disabled" href="#" aria-disabled="true" target="_blank" rel="noopener">Use GitHub instead</a>
   </div>
 
   <p id="submission-github-note" class="submission-github-note" role="note" hidden></p>
-  <p id="submission-status" class="submission-status" role="status" aria-live="polite"></p>
   <div id="submission-result" class="submission-result" role="status" aria-live="polite"></div>
-  <pre id="submission-preview" class="submission-preview" tabindex="-1" hidden aria-label="Prepared submission preview"></pre>
 </form>
 
-## Other ways to share
-
-<ul class="submission-routes">
-  <li class="submission-route">
-    <h3>Manual GitHub form</h3>
-    <p>If you already use GitHub, review the idea above and open the prepared form manually. This optional route requires a GitHub account.</p>
-  </li>
-  <li class="submission-route">
-    <h3>Community forum</h3>
-    <p>Review and copy the text above, then start a discussion on the <a href="https://forum.meshcore.ca/" target="_blank" rel="noopener">MeshCore Canada forum</a>.</p>
-  </li>
-  <li class="submission-route">
-    <h3>Discord</h3>
-    <p>For an informal conversation, copy the text and share it in the <a href="https://discord.gg/BESFVMt7yk" target="_blank" rel="noopener">MeshCore Canada Discord</a>.</p>
-  </li>
-</ul>
+<details class="submission-alternatives">
+  <summary>Prefer another way to share?</summary>
+  <p><a href="https://github.com/MeshCore-ca/MeshCore-Canada/issues/new?template=community_idea.yml" target="_blank" rel="noopener">GitHub form</a> (account required) · <a href="https://forum.meshcore.ca/" target="_blank" rel="noopener">Community forum</a> · <a href="https://discord.gg/BESFVMt7yk" target="_blank" rel="noopener">Discord</a></p>
+</details>
 
 ## What happens next?
 
-Maintainers will read the public issue, ask questions if something is unclear, and decide whether it belongs in the documentation, directory, tooling, or a future project. Submitting an idea does not guarantee implementation, but it makes the need visible and gives the community something concrete to discuss.
-
-If you already know GitHub, you can also open the [Share a Community Idea form](https://github.com/MeshCore-ca/MeshCore-Canada/issues/new?template=community_idea.yml) directly.
+Maintainers will read the public issue, ask questions if needed, and decide where it belongs. Submitting an idea does not guarantee implementation, but it gives the community something concrete to review.

--- a/docs/submit-idea.md
+++ b/docs/submit-idea.md
@@ -5,8 +5,8 @@ hide:
 # Share an idea
 
 <div class="submission-intro">
-  <p>Tell us what is missing, confusing, or difficult. We will turn your answers into a public issue for the MeshCore Canada maintainers. <strong>No GitHub account is needed.</strong></p>
-  <p class="submission-privacy"><strong>Keep it public.</strong> Do not include passwords, private keys, API tokens, exact home addresses, or private coordinates. A city or broad region is enough.</p>
+  <p>Share an idea or report a problem. <strong>No GitHub account needed.</strong></p>
+  <p class="submission-privacy"><strong>Public form.</strong> Do not include passwords, keys, addresses, or private coordinates.</p>
 </div>
 
 <form id="community-submission-form" class="submission-form" action="https://github.com/MeshCore-ca/MeshCore-Canada/issues/new" method="get" target="_blank" rel="noopener">
@@ -14,13 +14,13 @@ hide:
   <input type="hidden" name="source_page" value="https://meshcore.ca/submit-idea/">
   <noscript>
     <div class="submission-no-script" role="note">
-      <strong>JavaScript is turned off.</strong> This form will open the guided GitHub form instead, which requires a GitHub account.
+      <strong>JavaScript is off.</strong> Continue on GitHub (account required).
     </div>
   </noscript>
 
   <div class="submission-form__header">
     <h2>Describe your idea</h2>
-    <p>Five short fields are required. You can add more context if it is useful.</p>
+    <p>Five fields are required.</p>
   </div>
 
   <div class="submission-form__grid">
@@ -53,18 +53,18 @@ hide:
 
   <div class="submission-field">
     <label for="submission-summary">Short title</label>
-    <input id="submission-summary" name="summary" type="text" maxlength="100" autocomplete="off" placeholder="Example: Add a first-time repeater checklist" required>
+    <input id="submission-summary" name="summary" type="text" maxlength="100" autocomplete="off" placeholder="Example: Add a repeater checklist" required>
   </div>
 
   <div class="submission-form__grid submission-form__grid--ideas">
     <div class="submission-field">
       <label for="submission-need">What is difficult now?</label>
-      <textarea id="submission-need" name="need" maxlength="2000" rows="5" placeholder="What were you trying to do, and where did you get stuck?" required></textarea>
+      <textarea id="submission-need" name="need" maxlength="2000" rows="5" placeholder="What happened?" required></textarea>
     </div>
 
     <div class="submission-field">
       <label for="submission-idea">What would help?</label>
-      <textarea id="submission-idea" name="idea" maxlength="2000" rows="5" placeholder="Describe the improvement you would like." required></textarea>
+      <textarea id="submission-idea" name="idea" maxlength="2000" rows="5" placeholder="What should change?" required></textarea>
     </div>
   </div>
 
@@ -78,21 +78,21 @@ hide:
         </div>
 
         <div class="submission-field">
-          <label for="submission-follow-up">Public username for follow-up</label>
+          <label for="submission-follow-up">Public username</label>
           <input id="submission-follow-up" name="follow_up" type="text" maxlength="120" autocomplete="off" placeholder="Example: @meshfriend on Discord">
         </div>
       </div>
 
       <div class="submission-field">
         <label for="submission-context">Anything else?</label>
-        <textarea id="submission-context" name="context" maxlength="2000" rows="4" placeholder="Device, app, related page, what you tried, or who else this may help."></textarea>
+        <textarea id="submission-context" name="context" maxlength="2000" rows="4" placeholder="Device, app, page, or other details."></textarea>
       </div>
     </div>
   </details>
 
   <label class="submission-consent" for="submission-public">
     <input id="submission-public" name="public" type="checkbox" required>
-    <span>I understand this will be public and contains no secrets or exact private locations.</span>
+    <span>This can be posted publicly and contains no private information.</span>
   </label>
 
   <div class="submission-trap" aria-hidden="true">
@@ -124,10 +124,10 @@ hide:
 </form>
 
 <details class="submission-alternatives">
-  <summary>Prefer another way to share?</summary>
+  <summary>Other ways to share</summary>
   <p><a href="https://github.com/MeshCore-ca/MeshCore-Canada/issues/new?template=community_idea.yml&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fsubmit-idea%2F" target="_blank" rel="noopener">GitHub form</a> (account required) · <a href="https://forum.meshcore.ca/" target="_blank" rel="noopener">Community forum</a> · <a href="https://discord.gg/BESFVMt7yk" target="_blank" rel="noopener">Discord</a></p>
 </details>
 
 ## What happens next?
 
-Maintainers will read the public issue, ask questions if needed, and decide where it belongs. Submitting an idea does not guarantee implementation, but it gives the community something concrete to review.
+Maintainers will review the issue and follow up there.

--- a/docs/submit-idea.md
+++ b/docs/submit-idea.md
@@ -11,6 +11,7 @@ hide:
 
 <form id="community-submission-form" class="submission-form" action="https://github.com/MeshCore-ca/MeshCore-Canada/issues/new" method="get" target="_blank" rel="noopener">
   <input type="hidden" name="template" value="community_idea.yml">
+  <input type="hidden" name="source_page" value="https://meshcore.ca/submit-idea/">
   <noscript>
     <div class="submission-no-script" role="note">
       <strong>JavaScript is turned off.</strong> This form will open the guided GitHub form instead, which requires a GitHub account.
@@ -124,7 +125,7 @@ hide:
 
 <details class="submission-alternatives">
   <summary>Prefer another way to share?</summary>
-  <p><a href="https://github.com/MeshCore-ca/MeshCore-Canada/issues/new?template=community_idea.yml" target="_blank" rel="noopener">GitHub form</a> (account required) · <a href="https://forum.meshcore.ca/" target="_blank" rel="noopener">Community forum</a> · <a href="https://discord.gg/BESFVMt7yk" target="_blank" rel="noopener">Discord</a></p>
+  <p><a href="https://github.com/MeshCore-ca/MeshCore-Canada/issues/new?template=community_idea.yml&amp;source_page=https%3A%2F%2Fmeshcore.ca%2Fsubmit-idea%2F" target="_blank" rel="noopener">GitHub form</a> (account required) · <a href="https://forum.meshcore.ca/" target="_blank" rel="noopener">Community forum</a> · <a href="https://discord.gg/BESFVMt7yk" target="_blank" rel="noopener">Discord</a></p>
 </details>
 
 ## What happens next?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ extra_css:
 
 extra_javascript:
   - assets/regions/regions.js
+  - javascripts/submission-form.js
 
 plugins:
   - search
@@ -30,9 +31,6 @@ plugins:
         regions/setup.md: config/index.md
         regions/map.md: config/map.md
         regions/standard.md: config/standard.md
-
-extra_javascript:
-  - javascripts/submission-form.js
 
 markdown_extensions:
   - admonition

--- a/scripts/validate-regions.js
+++ b/scripts/validate-regions.js
@@ -543,7 +543,7 @@ function validate(data, meshMapper, partition, digitalPartition, qa, municipalOv
   check(!scriptText.includes("region dump"), "obsolete 'region dump' command remains in regions.js");
   check(scriptText.includes('verificationCommands = ["region"]'), "guided verification must use bare region command");
   check(scriptText.includes('commands.concat(["region", "region save", "region"])'), "technical flow must verify before and after saving");
-  check(scriptText.includes("Check, save, and verify"), "guided flow must verify before saving");
+  check(scriptText.includes("Run <code>region</code> and confirm:"), "guided flow must verify before saving");
   check(scriptText.includes("Too many regions selected"), "command generation must fail closed on firmware limits");
   check(scriptText.includes('"canada-region-partition.geojson"'), "UI does not load the generated partition");
   check(scriptText.includes('"canada-region-partition-digital.geojson"'), "UI does not load the complete resolver partition");

--- a/scripts/validate_community_submission.py
+++ b/scripts/validate_community_submission.py
@@ -9,6 +9,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 HELPER_PATH = ROOT / "docs" / "submit-idea.md"
 ISSUE_FORM_PATH = ROOT / ".github" / "ISSUE_TEMPLATE" / "community_idea.yml"
+SOURCE_PAGE = "https://meshcore.ca/submit-idea/"
 
 
 class CommunityFormParser(HTMLParser):
@@ -77,11 +78,17 @@ def main() -> None:
     assert parser.controls.get("template", {}).get("value") == (
         "community_idea.yml"
     ), "No-JavaScript fallback must select the community issue template"
+    assert parser.controls.get("source_page", {}).get("value") == SOURCE_PAGE, (
+        "No-JavaScript fallback must identify its source page"
+    )
 
     issue_form = yaml.safe_load(ISSUE_FORM_PATH.read_text(encoding="utf-8"))
     issue_fields = {
         field["id"]: field for field in issue_form["body"] if field["type"] != "markdown"
     }
+    assert issue_fields["source_page"]["attributes"].get("value") == SOURCE_PAGE, (
+        "GitHub issue form must preserve the source-page backlink"
+    )
     helper_fields = set(parser.controls) - {"template"}
     assert helper_fields == set(issue_fields), (
         "Helper fields do not match GitHub issue fields: "

--- a/tests/editor/community-submission.test.mjs
+++ b/tests/editor/community-submission.test.mjs
@@ -91,7 +91,10 @@ test("page exposes anonymous submission, anti-spam, result, and manual fallback 
     readFile(new URL("../../docs/javascripts/submission-form.js", import.meta.url), "utf8")
   ]);
   for (const id of [
+    "review-submission",
     "submit-community-idea",
+    "submission-verification",
+    "submission-final-actions",
     "submission-turnstile",
     "submission-anti-spam-status",
     "submission-anti-spam-retry",
@@ -103,6 +106,11 @@ test("page exposes anonymous submission, anti-spam, result, and manual fallback 
     assert.ok(html.includes(`id="${id}"`), `missing ${id}`);
   }
   assert.match(html, /No GitHub account is needed/);
+  assert.match(html, /<details class="submission-optional">/);
+  assert.match(html, /id="submission-final-actions" class="submission-actions" hidden/);
+  assert.match(controller, /elements\.finalActions\.hidden = !current/);
+  assert.match(controller, /void initialiseSubmission\(\)/);
+  assert.doesNotMatch(controller, /\n  initialiseSubmission\(\);\n/);
   assert.match(controller, /import\(transportModuleUrl\)/);
   assert.match(controller, /submitSubmission\(/);
   assert.match(controller, /COMMUNITY_SUBMISSION_ENDPOINT/);

--- a/tests/editor/community-submission.test.mjs
+++ b/tests/editor/community-submission.test.mjs
@@ -71,7 +71,7 @@ test("keeps preview and bounded manual GitHub fallbacks", () => {
   const proposal = buildCommunityIdea(validData);
   const preview = buildSubmissionText(proposal);
   assert.match(preview, /^# Make the setup note clearer/m);
-  assert.match(preview, /## Public follow-up contact\n\n@meshfriend/);
+  assert.match(preview, /## Public contact\n\n@meshfriend/);
   const manual = buildManualGithubLink(proposal);
   assert.equal(manual.fullyPrefilled, true);
   assert.equal(new URL(manual.url).searchParams.get("source_page"), COMMUNITY_SOURCE_PAGE);
@@ -116,7 +116,7 @@ test("page exposes anonymous submission, anti-spam, result, and manual fallback 
   ]) {
     assert.ok(html.includes(`id="${id}"`), `missing ${id}`);
   }
-  assert.match(html, /No GitHub account is needed/);
+  assert.match(html, /No GitHub account needed/);
   assert.match(html, /name="source_page" value="https:\/\/meshcore\.ca\/submit-idea\/"/);
   assert.match(html, /<details class="submission-optional">/);
   assert.match(html, /id="submission-final-actions" class="submission-actions" hidden/);

--- a/tests/editor/community-submission.test.mjs
+++ b/tests/editor/community-submission.test.mjs
@@ -4,6 +4,7 @@ import { readFile } from "node:fs/promises";
 import { DEFAULT_SUBMISSION_ENDPOINT } from "../../docs/config/editor/issue.js";
 import {
   COMMUNITY_IDEA_SCHEMA,
+  COMMUNITY_SOURCE_PAGE,
   COMMUNITY_SUBMISSION_ENDPOINT,
   buildCommunityIdea,
   buildManualGithubLink,
@@ -71,7 +72,9 @@ test("keeps preview and bounded manual GitHub fallbacks", () => {
   const preview = buildSubmissionText(proposal);
   assert.match(preview, /^# Make the setup note clearer/m);
   assert.match(preview, /## Public follow-up contact\n\n@meshfriend/);
-  assert.equal(buildManualGithubLink(proposal).fullyPrefilled, true);
+  const manual = buildManualGithubLink(proposal);
+  assert.equal(manual.fullyPrefilled, true);
+  assert.equal(new URL(manual.url).searchParams.get("source_page"), COMMUNITY_SOURCE_PAGE);
 
   const long = buildCommunityIdea({
     ...validData,
@@ -82,7 +85,15 @@ test("keeps preview and bounded manual GitHub fallbacks", () => {
   const fallback = buildManualGithubLink(long);
   assert.equal(fallback.fullyPrefilled, false);
   assert.match(fallback.url, /template=community_idea\.yml/);
+  assert.equal(new URL(fallback.url).searchParams.get("source_page"), COMMUNITY_SOURCE_PAGE);
   assert.doesNotMatch(fallback.url, /need=/);
+});
+
+test("MkDocs loads the configurator and submission scripts together", async () => {
+  const config = await readFile(new URL("../../mkdocs.yml", import.meta.url), "utf8");
+  assert.equal((config.match(/^extra_javascript:/gm) || []).length, 1);
+  assert.match(config, /^\s+- assets\/regions\/regions\.js$/m);
+  assert.match(config, /^\s+- javascripts\/submission-form\.js$/m);
 });
 
 test("page exposes anonymous submission, anti-spam, result, and manual fallback controls", async () => {
@@ -106,6 +117,7 @@ test("page exposes anonymous submission, anti-spam, result, and manual fallback 
     assert.ok(html.includes(`id="${id}"`), `missing ${id}`);
   }
   assert.match(html, /No GitHub account is needed/);
+  assert.match(html, /name="source_page" value="https:\/\/meshcore\.ca\/submit-idea\/"/);
   assert.match(html, /<details class="submission-optional">/);
   assert.match(html, /id="submission-final-actions" class="submission-actions" hidden/);
   assert.match(controller, /elements\.finalActions\.hidden = !current/);


### PR DESCRIPTION
## Summary

- restore the repeater configurator and map by loading the region application and submission helper from one MkDocs `extra_javascript` list
- add a regression test that rejects duplicate MkDocs script keys and requires both scripts
- replace the decorative Share an Idea hero, duplicate callouts, and fallback card grid with a conventional page hierarchy
- reduce the idea form to five required fields and move optional details behind one disclosure
- add a review-first flow so preview, anti-spam, and final actions appear only when needed
- defer anti-spam loading until review and clarify its unavailable state
- preserve the anonymous submission endpoint and payload contract
- add a `Source page` field to manual GitHub issues and prefill it from every manual, oversized, direct, and no-JavaScript route
- simplify labels, help text, and status messages across Share an Idea, the configurator, region map, and boundary editor
- keep the actionable USB serial and LoRa remote-management instructions while removing repeated explanations
- add the community helper/schema validator to pull-request CI and keep the guided-flow wording guard aligned with the concise copy

## Root cause

`mkdocs.yml` defined `extra_javascript` twice. YAML kept only the later definition, so `assets/regions/regions.js` was absent from the deployed page. The configurator root remained in the HTML but no application code initialized it.

## User impact

The repeater configurator and region map render again. Share an Idea is shorter and linear on desktop and mobile. The setup, map, and editor now use concise prompts without changing the region authority data or review workflow. Contributors who choose GitHub receive a prefilled issue containing a clickable backlink to `https://meshcore.ca/submit-idea/`.

## Validation

- `mkdocs build --strict`
- JavaScript syntax checks for the configurator, editor, submission controller, and shared transport
- `python scripts/validate_community_submission.py`
- 39 Node editor, transport, and community-submission tests
- 35 gateway tests passed; one expected POSIX-only permission test skipped on Windows
- national region data validation and both no-overlap geometry partition checks
- desktop visual QA for Share an Idea, the configurator, national region map, and boundary editor
- browser interaction check of the review-before-submit flow
- local browser proof that `/config/` initializes its four-step interface
- local browser proof that all three manual GitHub routes carry the source-page backlink
