### PR TITLE
Automate approved boundary updates

### DIFF
--- a/.github/region-boundary-automation.json
+++ b/.github/region-boundary-automation.json
@@ -1,0 +1,10 @@
+{
+  "schema": "mcc-region-boundary-automation/v1",
+  "label": "boundary-update",
+  "repository": "MeshCore-ca/MeshCore-Canada",
+  "approvers": ["MrAlders0n", "n30nex"],
+  "submissionBots": [
+    "meshcore-canada-submissions[bot]",
+    "app/meshcore-canada-submissions"
+  ]
+}

--- a/.github/workflows/apply-approved-boundary.yml
+++ b/.github/workflows/apply-approved-boundary.yml
@@ -1,0 +1,172 @@
+name: Apply approved boundary update
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: write
+  issues: write
+
+concurrency:
+  group: region-boundary-application
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    if: >-
+      github.event.issue.state_reason == 'completed' &&
+      contains(github.event.issue.labels.*.name, 'boundary-update')
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+
+    steps:
+      - name: Checkout current authority
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "22"
+
+      - name: Fetch proposal comments
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" \
+            > "$RUNNER_TEMP/issue-comments.json"
+
+      - name: Install submission verification key
+        shell: bash
+        env:
+          PUBLIC_KEY_PEM: ${{ secrets.MCC_SUBMISSION_PUBLIC_KEY_PEM }}
+        run: |
+          set -euo pipefail
+          test -n "$PUBLIC_KEY_PEM"
+          printf '%s\n' "$PUBLIC_KEY_PEM" > "$RUNNER_TEMP/submission-public-key.pem"
+          chmod 0600 "$RUNNER_TEMP/submission-public-key.pem"
+
+      - name: Verify approval and record reviewed decision
+        id: apply
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/apply-approved-region-issue.py \
+            --event "$GITHUB_EVENT_PATH" \
+            --comments "$RUNNER_TEMP/issue-comments.json" \
+            --public-key "$RUNNER_TEMP/submission-public-key.pem" \
+            --summary "$RUNNER_TEMP/boundary-application.json" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Fetch locked census sources
+        id: sources
+        if: steps.apply.outputs.already_applied != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/fetch-locked-region-sources.py \
+            --cache-dir "$RUNNER_TEMP/region-sources" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Install region generator dependencies
+        if: steps.apply.outputs.already_applied != 'true'
+        run: python -m pip install -r scripts/requirements-regions.txt
+
+      - name: Regenerate the national partition
+        if: steps.apply.outputs.already_applied != 'true'
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/generate-region-partition.py \
+            --digital-da "${{ steps.sources.outputs.digital_da }}" \
+            --cartographic-da "${{ steps.sources.outputs.cartographic_da }}" \
+            --economic-regions "${{ steps.sources.outputs.economic_regions }}" \
+            --census-divisions "${{ steps.sources.outputs.census_divisions }}" \
+            --census-subdivisions "${{ steps.sources.outputs.census_subdivisions }}"
+          python scripts/build-region-editor-data.py \
+            --digital-da "${{ steps.sources.outputs.digital_da }}" \
+            --census-subdivisions "${{ steps.sources.outputs.census_subdivisions }}" \
+            --census-divisions "${{ steps.sources.outputs.census_divisions }}" \
+            --membership docs/assets/regions/canada-region-membership.csv \
+            --catalog docs/assets/regions/canada-regions.json \
+            --retain 10% \
+            --output-dir docs/assets/regions/cells
+
+      - name: Validate regenerated authority
+        if: steps.apply.outputs.already_applied != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/validate-regions.js
+          python scripts/verify-region-geometry.py
+          python scripts/verify-region-geometry.py \
+            --partition docs/assets/regions/canada-region-partition-digital.geojson
+          python -m unittest discover -s tools/region-proposal-gateway/tests -v
+          python -m unittest discover -s tests/automation -v
+          node --test tests/editor/*.test.mjs
+
+      - name: Publish approved authority
+        id: publish
+        if: steps.apply.outputs.already_applied != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff --check
+          git add docs/assets/regions
+          if git diff --cached --quiet; then
+            echo "Approved proposal produced no authority change." >&2
+            exit 1
+          fi
+          git config user.name "MeshCore Canada Boundary Automation"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Apply boundary update #$ISSUE_NUMBER"
+          git push origin HEAD:main
+          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "APPLIED=1" >> "$GITHUB_ENV"
+
+      - name: Queue site deployment
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run deploy.yml --ref main
+
+      - name: Record successful application
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.apply.outputs.already_applied }}" == "true" ]]; then
+            message="This boundary update was already applied. A fresh site deployment has been queued."
+          else
+            sha="${{ steps.publish.outputs.commit_sha }}"
+            message="Boundary update approved and applied in [\`${sha:0:7}\`](https://github.com/$GITHUB_REPOSITORY/commit/$sha). A site deployment has been queued."
+          fi
+          gh issue comment "$ISSUE_NUMBER" --body "$message"
+
+      - name: Report a failed application
+        if: failure()
+        shell: bash
+        run: |
+          set +e
+          if [[ "${APPLIED:-0}" == "1" ]]; then
+            gh issue comment "$ISSUE_NUMBER" --body \
+              "The boundary commit succeeded, but a follow-up step failed. Check this Action run and re-run the site deployment."
+          else
+            gh issue comment "$ISSUE_NUMBER" --body \
+              "The boundary update was not published because automated verification or regeneration failed. The issue has been reopened; check this Action run before approving it again."
+            gh issue reopen "$ISSUE_NUMBER"
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]  # change to master if your branch is named master
   release:
     types: [ published ]  # redeploy site when new firmware is released
+  workflow_dispatch:
 
 permissions:
   contents: write       # needed so the action can push to gh-pages

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,9 @@ jobs:
           python-version: "3.13"
 
       - name: Validate anonymous proposal gateway
-        run: python -m unittest discover -s tools/region-proposal-gateway/tests -v
+        run: |
+          python -m unittest discover -s tools/region-proposal-gateway/tests -v
+          python -m unittest discover -s tests/automation -v
 
       - name: Enforce MeshCore Canada production ownership
         shell: bash

--- a/docs/config/standard.md
+++ b/docs/config/standard.md
@@ -308,14 +308,20 @@ The national maintainers enforce the data model; they do not invent local identi
 2. Generate a before/after diff and QA report.
 3. Obtain affected local and jurisdiction review. Cross-boundary proposals require every affected side.
 4. Allow a public review window recorded in the proposal.
-5. Merge the registry change and publish a versioned release.
-6. Keep the previous release available for rollback and migration.
+5. An allowlisted maintainer approves by closing the `boundary-update` issue
+   as **Completed**. **Close as not planned** rejects it.
+6. The repository Action verifies the signed proposal, records the reviewed
+   census decision, regenerates and validates the full national layer, commits
+   it to `main`, and queues publication.
+7. Keep the previous release available for rollback and migration.
 
 ### Boundary editor proposals
 
 The boundary editor works on the same census cells as the generator. Its normal action reassigns a whole CSD, with its containing CD shown as review context. It never saves a freehand polygon as operational geometry. A reviewer may use DA-level draft edits to shape an exceptional split, but the approved `splitExceptions` record must expand that draft to list every DA in the CSD, with no duplicate or missing DGUID.
 
-The editor is a static page at `/config/editor/` and requires no contributor account. It builds a versioned proposal with the base membership hash and before/after owner for each changed DGUID. On submission, a MeshCore Canada-hosted proposal service repeats the authority and proposal checks, verifies the anti-spam challenge, and uses a repository-restricted GitHub App to open the public review issue automatically. The static page and production service are both operated by MeshCore Canada; no GitHub credential or signing secret is placed in the browser. Maintainers may reproduce the proposal check with `scripts/validate-region-proposal.py`, which adds CD/CSD context and requires a reason before review; an author may also be recorded. A maintainer must review and merge the resulting decision into `municipal-overrides.json`, regenerate all artifacts, and pass the release checks before the public boundary changes. Editor drafts, browser-local state, and submitted issues are never operational authority.
+The editor is a static page at `/config/editor/` and requires no contributor account. It builds a versioned proposal with the base membership hash and before/after owner for each changed DGUID. On submission, a MeshCore Canada-hosted proposal service repeats the authority and proposal checks, verifies the anti-spam challenge, and uses a repository-restricted GitHub App to open the public review issue automatically. The static page and production service are both operated by MeshCore Canada; no GitHub credential or signing secret is placed in the browser. The public App has Issues read/write only and cannot change the map. The canonical proposal is signed by the App and stored in machine-readable issue markers while the issue shows the human review summary. Maintainers may reproduce the proposal check with `scripts/validate-region-proposal.py`, which adds CD/CSD context and requires a reason before review; an author may also be recorded.
+
+After local and public review, an allowlisted maintainer closes the labelled issue as **Completed**. The repository-owned Action independently verifies the issue author, closer, label, App signature, proposal hash, current base membership, and jurisdiction. A whole-CSD decision becomes a cohort override; a partial-CSD decision becomes an explicit split listing every DA in that CSD. The Action then regenerates both national partitions and editor cells from locked sources, runs the release checks, commits the source decision and generated artifacts to `main`, and queues the site deployment. Any failure before publication reopens the issue and leaves `main` unchanged. Closing as **Not planned** makes no authority change. Editor drafts, browser-local state, and submitted issues are never operational authority until this approval and validation complete.
 
 The editor's own census-cell geometry (`docs/assets/regions/cells/`) was last regenerated with `scripts/build-region-editor-data.py --retain 10%` rather than the script's 8% default, because 8% collapses a BC dissemination area to a degenerate shape; the retained value is recorded alongside the rest of the build inputs in `docs/assets/regions/cells/manifest.json`.
 

--- a/instructions.md
+++ b/instructions.md
@@ -309,8 +309,11 @@ Do these one-time repository-owner steps before testing a boundary submission:
 
 1. Create the `boundary-update` issue label. The gateway adds it only to
    boundary proposals; community ideas remain ordinary `enhancement` issues.
-2. In **Settings -> Actions -> General -> Workflow permissions**, select
-   **Read and write permissions**.
+2. Keep the repository's default workflow permission **Read repository
+   contents and packages permissions**, and keep **Allow GitHub Actions to
+   create and approve pull requests** disabled. The boundary workflow requests
+   only `actions: write`, `contents: write`, and `issues: write` in its own
+   `permissions` block.
 3. Confirm the maintainer logins in
    `.github/region-boundary-automation.json`. Only those users may approve a
    boundary by closing its issue.
@@ -408,7 +411,8 @@ curl -fsS http://127.0.0.1:8787/healthz
 - [ ] Caddy presents a valid certificate on `api.meshcore.ca:21323`.
 - [ ] GitHub App is installed only on `MeshCore-ca/MeshCore-Canada` with Issues
       read/write and no Contents permission.
-- [ ] `boundary-update` exists; Actions has read/write workflow permissions.
+- [ ] `boundary-update` exists; the repository workflow default remains
+      read-only and Action pull-request approval remains disabled.
 - [ ] `MCC_SUBMISSION_PUBLIC_KEY_PEM` contains the public key derived from the
       production App PEM; the App itself still has no Contents permission.
 - [ ] Approved maintainer logins in `.github/region-boundary-automation.json`

--- a/instructions.md
+++ b/instructions.md
@@ -4,17 +4,18 @@ Give this file to the MeshCore Canada administrator. It activates one
 MeshCore Canada-owned service for both public community ideas and region
 boundary proposals. Contributors do not need GitHub accounts.
 
-## Do not merge PR #39 first
+## Activation order
 
-Provision and verify the service from the PR branch before merging. The safe
-order is:
+Provision and verify the public submission service from the pull-request branch
+before merging. Then enable the repository-owned approval Action:
 
 1. Create the organization-owned GitHub App and Turnstile widget.
 2. Deploy the PR branch on the MeshCore Canada production host.
 3. Configure DNS, firewall, Caddy, TLS, health, and CORS.
-4. Merge PR #39 only after the public API checks pass.
-5. Let the existing GitHub Pages workflow publish `main`.
-6. Switch the host checkout to `main`, rebuild, and test both forms signed out.
+4. Create the `boundary-update` label and add the Action verification key.
+5. Merge the reviewed pull request only after the public API checks pass.
+6. Let GitHub Pages publish `main`, switch the host checkout to `main`, and
+   test both forms signed out.
 
 The fixed public endpoint is:
 
@@ -36,6 +37,12 @@ api.meshcore.ca:21323/api/meshcore-canada/submissions
               | short-lived repository-restricted installation token
               v
 MeshCore Canada GitHub App -> MeshCore-ca/MeshCore-Canada issue
+                                      | maintainer closes Completed
+                                      v
+                       repository-owned approval Action
+                                      | verify, regenerate, validate
+                                      v
+                         main -> GitHub Pages deployment
 ```
 
 The API accepts two strict schemas:
@@ -44,9 +51,11 @@ The API accepts two strict schemas:
 - `mcc-region-editor-proposal/v1` revalidates the proposed census-cell moves
   against the mounted region authority, then creates a public boundary issue.
 
-The service creates issues only. It cannot change repository contents or make
-a boundary live. The GitHub App, Turnstile account, DNS, host, TLS, secrets,
-and repository installation must all be controlled by MeshCore Canada.
+The public service creates issues only. It has no Contents permission and
+cannot make a boundary live. A separate repository-owned GitHub Action applies
+an approved boundary after a maintainer closes its issue as **Completed**.
+The GitHub App, Turnstile account, DNS, host, TLS, secrets, repository
+installation, and Action settings must all be controlled by MeshCore Canada.
 
 ## 1. Create the GitHub App
 
@@ -106,7 +115,7 @@ Allow outbound HTTPS to GitHub, Turnstile, and the selected ACME provider.
 
 Do **not** expose container port `8787`; it must remain on loopback.
 
-## 4. Check out PR #39 before merging
+## 4. Check out the pull request before merging
 
 The supplied paths and Compose defaults are:
 
@@ -121,11 +130,12 @@ image:    meshcore-canada/submission-gateway:production
 On the production host:
 
 ```sh
+PR_NUMBER=NN  # replace NN with the pull-request number
 sudo git clone https://github.com/MeshCore-ca/MeshCore-Canada.git \
   /opt/meshcore-canada
 sudo git -C /opt/meshcore-canada fetch origin \
-  pull/39/head:pr-39-submissions
-sudo git -C /opt/meshcore-canada switch pr-39-submissions
+  "pull/${PR_NUMBER}/head:submission-pr-${PR_NUMBER}"
+sudo git -C /opt/meshcore-canada switch "submission-pr-${PR_NUMBER}"
 sudo git -C /opt/meshcore-canada status --short --branch
 sudo git -C /opt/meshcore-canada rev-parse HEAD
 ```
@@ -271,7 +281,7 @@ Do not merge until these checks pass.
 
 ## 9. Merge, publish, and switch to `main`
 
-1. Merge [PR #39](https://github.com/MeshCore-ca/MeshCore-Canada/pull/39).
+1. Merge the reviewed pull request.
 2. Wait for the repository validation and `Deploy MkDocs site` workflow.
 3. Confirm the new pages and JavaScript are live at `meshcore.ca`.
 4. Switch the service checkout to the exact published `main` revision:
@@ -293,7 +303,45 @@ Keep the host checkout synchronized whenever `docs/assets/regions` changes.
 If the static editor and mounted authority differ, boundary proposals fail
 closed as stale; community ideas continue to use their independent schema.
 
-## 10. Test both flows without a GitHub account
+## 10. Enable approved boundary application
+
+Do these one-time repository-owner steps before testing a boundary submission:
+
+1. Create the `boundary-update` issue label. The gateway adds it only to
+   boundary proposals; community ideas remain ordinary `enhancement` issues.
+2. In **Settings -> Actions -> General -> Workflow permissions**, select
+   **Read and write permissions**.
+3. Confirm the maintainer logins in
+   `.github/region-boundary-automation.json`. Only those users may approve a
+   boundary by closing its issue.
+4. Derive a public verification key from the same GitHub App private key used
+   by the gateway, store it as the repository Actions secret
+   `MCC_SUBMISSION_PUBLIC_KEY_PEM`, and remove the temporary file:
+
+```sh
+sudo openssl pkey \
+  -in /etc/meshcore-submissions/github-app.pem \
+  -pubout -out /tmp/mcc-submission-public.pem
+gh secret set MCC_SUBMISSION_PUBLIC_KEY_PEM \
+  --repo MeshCore-ca/MeshCore-Canada \
+  < /tmp/mcc-submission-public.pem
+sudo rm -f /tmp/mcc-submission-public.pem
+```
+
+The public key can verify the gateway signature but cannot create one. The
+GitHub App keeps Issues read/write only; do not grant it Contents access.
+
+For an accepted proposal, an allowlisted maintainer closes the labelled issue
+as **Completed**. The Action verifies the App author, closer, label, payload
+hash, App signature, current membership hash, and province. It records the
+reviewed CSD/DA decision, regenerates the full national layer from locked
+sources, runs the release checks, commits to `main`, and queues the site
+deployment. A failed check publishes nothing and reopens the issue.
+
+To reject or close a test without changing the map, choose **Close as not
+planned**. Removing the label also prevents application.
+
+## 11. Test both flows without a GitHub account
 
 Use a signed-out private browser.
 
@@ -312,8 +360,9 @@ Use a signed-out private browser.
 2. Make one small valid same-province draft move.
 3. Use reason `Production anonymous boundary test — do not apply`.
 4. Complete Turnstile and select **Submit for review**.
-5. Confirm the App-created issue contains the signed hash and canonical data.
-6. Close it without applying the boundary change.
+5. Confirm the App-created issue has `enhancement` and `boundary-update`
+   labels, a readable summary, and signed submission markers.
+6. Choose **Close as not planned** and confirm no boundary commit is created.
 
 Both pages must retain their copy/download or manual fallback when the API is
 unavailable. Neither flow should request a GitHub login for direct submission.
@@ -337,6 +386,8 @@ curl -fsS http://127.0.0.1:8787/healthz
   only `submission-gateway`.
 - To roll back the website, revert the responsible commit on `main` and let the
   normal Pages workflow publish the revert. Do not force-push production.
+- To roll back an approved boundary, revert its `Apply boundary update #N`
+  commit. The source decision and every generated artifact are in that commit.
 - Before migration or ledger maintenance, stop the gateway and back up
   `/var/lib/meshcore-submissions`. Never delete a confirmed `created` row.
 - If a row remains `pending`, audit GitHub for its signed hash before changing
@@ -357,11 +408,17 @@ curl -fsS http://127.0.0.1:8787/healthz
 - [ ] Caddy presents a valid certificate on `api.meshcore.ca:21323`.
 - [ ] GitHub App is installed only on `MeshCore-ca/MeshCore-Canada` with Issues
       read/write and no Contents permission.
+- [ ] `boundary-update` exists; Actions has read/write workflow permissions.
+- [ ] `MCC_SUBMISSION_PUBLIC_KEY_PEM` contains the public key derived from the
+      production App PEM; the App itself still has no Contents permission.
+- [ ] Approved maintainer logins in `.github/region-boundary-automation.json`
+      are current.
 - [ ] Turnstile validates `meshcore.ca`, `config.meshcore.ca`, and action
       `meshcore_submission`.
 - [ ] Loopback health, public config, allowed CORS, denied CORS, and preflight
       checks pass before merge.
-- [ ] PR #39 is merged and GitHub Pages publishes successfully.
+- [ ] The reviewed pull request is merged and GitHub Pages publishes
+      successfully.
 - [ ] Signed-out idea and boundary submissions each create a test issue.
-- [ ] Both test issues are closed; no test boundary is applied.
+- [ ] The boundary test is closed as not planned; no test boundary is applied.
 - [ ] Production checkout is on clean `main` and the ledger is backed up.

--- a/scripts/apply-approved-region-issue.py
+++ b/scripts/apply-approved-region-issue.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""Verify an approved boundary issue and record its reviewed census decision."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import gzip
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROPOSAL_SCHEMA = "mcc-region-editor-proposal/v1"
+AUTOMATION_SCHEMA = "mcc-region-boundary-automation/v1"
+OVERRIDES_SCHEMA = "mcc-census-overrides/v1"
+SOURCE_ID = "meshcore-canada-reviewed-census-overrides"
+SIGNATURE_DOMAIN = "mcc-submission/v1"
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+BASE64URL_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+PR_TO_TAG = {
+    "10": "nl", "11": "pe", "12": "ns", "13": "nb", "24": "qc",
+    "35": "on", "46": "mb", "47": "sk", "48": "ab", "59": "bc",
+    "60": "yt", "61": "nt", "62": "nu",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event", type=Path, required=True)
+    parser.add_argument("--comments", type=Path, required=True)
+    parser.add_argument("--public-key", type=Path, required=True)
+    parser.add_argument("--config", type=Path, default=ROOT / ".github" / "region-boundary-automation.json")
+    parser.add_argument("--membership", type=Path, default=ROOT / "docs" / "assets" / "regions" / "canada-region-membership.csv")
+    parser.add_argument("--catalog", type=Path, default=ROOT / "docs" / "assets" / "regions" / "canada-regions.json")
+    parser.add_argument("--cells-dir", type=Path, default=ROOT / "docs" / "assets" / "regions" / "cells")
+    parser.add_argument("--overrides", type=Path, default=ROOT / "docs" / "assets" / "regions" / "municipal-overrides.json")
+    parser.add_argument("--sources-lock", type=Path, default=ROOT / "docs" / "assets" / "regions" / "sources.lock.json")
+    parser.add_argument("--summary", type=Path)
+    parser.add_argument("--github-output", type=Path)
+    return parser.parse_args()
+
+
+def read_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def canonical_bytes(value: object) -> bytes:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def pretty_bytes(value: object) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def write_atomic(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_bytes(payload)
+    os.replace(temporary, path)
+
+
+def single_marker(body: str, name: str, pattern: str) -> str:
+    matches = re.findall(pattern, body)
+    if len(matches) != 1:
+        raise ValueError(f"issue must contain exactly one {name} marker")
+    return str(matches[0])
+
+
+def decode_base64url(value: str) -> bytes:
+    if not value or not BASE64URL_RE.fullmatch(value):
+        raise ValueError("submission payload contains invalid base64url data")
+    try:
+        return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+    except Exception as exc:
+        raise ValueError("submission payload contains invalid base64url data") from exc
+
+
+def flatten_comments(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ValueError("issue comments response must be an array")
+    flattened: list[dict[str, Any]] = []
+    for entry in value:
+        if isinstance(entry, list):
+            flattened.extend(item for item in entry if isinstance(item, dict))
+        elif isinstance(entry, dict):
+            flattened.append(entry)
+    return flattened
+
+
+def actor_login(value: dict[str, Any]) -> str:
+    for key in ("user", "author"):
+        actor = value.get(key)
+        if isinstance(actor, dict) and isinstance(actor.get("login"), str):
+            return actor["login"]
+    return ""
+
+
+def extract_payload(body: str, comments: list[dict[str, Any]], proposal_hash: str, submission_bots: set[str]) -> bytes:
+    inline = re.findall(r"<!-- submission-payload-gzip-base64url:([A-Za-z0-9_-]+) -->", body)
+    if len(inline) > 1:
+        raise ValueError("issue contains duplicate inline submission payloads")
+    if inline:
+        try:
+            return gzip.decompress(decode_base64url(inline[0]))
+        except (OSError, EOFError) as exc:
+            raise ValueError("inline submission payload is not valid gzip data") from exc
+
+    legacy = re.findall(
+        r"### Canonical proposal JSON\s*\n+(?P<fence>`{3,})json\s*\n"
+        r"(?P<payload>.*?)\n(?P=fence)(?:\n|$)",
+        body,
+        flags=re.DOTALL,
+    )
+    if len(legacy) > 1:
+        raise ValueError("issue contains duplicate legacy submission payloads")
+    if legacy:
+        return legacy[0][1].encode("utf-8")
+
+    declared = re.findall(r"<!-- submission-payload-chunks:(\d{1,3}) -->", body)
+    if not declared:
+        declared = re.findall(r"stored in \*\*(\d{1,3})\*\* ordered issue comment", body)
+    if len(declared) != 1:
+        raise ValueError("issue does not contain one complete submission payload")
+    total = int(declared[0])
+    if total < 1 or total > 100:
+        raise ValueError("issue declares an invalid submission chunk count")
+    chunks: dict[int, str] = {}
+    marker_re = re.compile(
+        rf"<!-- mcc-submission-chunk:{re.escape(proposal_hash)}:(\d{{1,3}})/(\d{{1,3}}) -->"
+    )
+    for comment in comments:
+        comment_body = str(comment.get("body", ""))
+        marker = marker_re.search(comment_body)
+        if not marker:
+            continue
+        if actor_login(comment).lower() not in submission_bots:
+            raise ValueError("a submission payload chunk was not posted by the submission App")
+        index, marker_total = int(marker.group(1)), int(marker.group(2))
+        if marker_total != total or index < 1 or index > total:
+            raise ValueError("submission payload chunk numbering is inconsistent")
+        hidden = re.findall(r"<!-- submission-payload-chunk-gzip-base64url:([A-Za-z0-9_-]+) -->", comment_body)
+        legacy_chunk = re.findall(r"```text\s*\n([A-Za-z0-9_-]+)\n```", comment_body)
+        values = hidden or legacy_chunk
+        if len(values) != 1:
+            raise ValueError("submission payload chunk is malformed")
+        if index in chunks and chunks[index] != values[0]:
+            raise ValueError("submission payload contains conflicting duplicate chunks")
+        chunks[index] = values[0]
+    if set(chunks) != set(range(1, total + 1)):
+        raise ValueError("submission payload is missing one or more chunks")
+    try:
+        return gzip.decompress(decode_base64url("".join(chunks[index] for index in range(1, total + 1))))
+    except (OSError, EOFError) as exc:
+        raise ValueError("chunked submission payload is not valid gzip data") from exc
+
+
+def verify_signature(public_key: Path, message: bytes, signature: bytes) -> None:
+    if not public_key.is_file():
+        raise ValueError("submission verification public key is unavailable")
+    openssl = shutil.which("openssl")
+    if not openssl:
+        raise ValueError("openssl is required to verify the submission signature")
+    with tempfile.TemporaryDirectory(prefix="mcc-submission-signature-") as temporary:
+        root = Path(temporary)
+        message_path, signature_path = root / "message", root / "signature"
+        message_path.write_bytes(message)
+        signature_path.write_bytes(signature)
+        result = subprocess.run(
+            [openssl, "dgst", "-sha256", "-verify", str(public_key), "-signature", str(signature_path), str(message_path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    if result.returncode != 0:
+        raise ValueError("submission signature verification failed")
+
+
+def catalog_leaves(catalog: dict[str, Any]) -> tuple[set[str], dict[str, str]]:
+    hierarchy = catalog.get("hierarchy")
+    if not isinstance(hierarchy, dict):
+        raise ValueError("region catalog hierarchy is invalid")
+    parents = {str(entry.get("parent")) for entry in hierarchy.values() if isinstance(entry, dict) and entry.get("parent")}
+    leaves = set(hierarchy) - parents
+    jurisdictions: dict[str, str] = {}
+    for leaf in leaves:
+        path: list[str] = []
+        seen: set[str] = set()
+        current: Any = leaf
+        while current:
+            if not isinstance(current, str) or current in seen or current not in hierarchy:
+                raise ValueError(f"catalog ancestry is invalid for {leaf}")
+            seen.add(current)
+            path.insert(0, current)
+            current = hierarchy[current].get("parent")
+        if len(path) < 3 or path[0] != "can":
+            raise ValueError(f"catalog leaf {leaf} has no Canadian jurisdiction")
+        jurisdictions[leaf] = path[1]
+    return leaves, jurisdictions
+
+
+def label_names(issue: dict[str, Any]) -> set[str]:
+    return {
+        label if isinstance(label, str) else str(label.get("name", ""))
+        for label in issue.get("labels", [])
+        if isinstance(label, (str, dict))
+    }
+
+
+def validate_event(event: dict[str, Any], config: dict[str, Any]) -> tuple[dict[str, Any], int, str, str]:
+    if config.get("schema") != AUTOMATION_SCHEMA:
+        raise ValueError("boundary automation configuration schema is invalid")
+    issue = event.get("issue")
+    if event.get("action") != "closed" or not isinstance(issue, dict):
+        raise ValueError("automation accepts only an issue closed event")
+    if issue.get("state") != "closed" or issue.get("state_reason") != "completed":
+        raise ValueError("boundary issue was not closed as completed")
+    label = str(config.get("label", ""))
+    if label not in label_names(issue):
+        raise ValueError(f"boundary issue is missing the {label} label")
+    sender = event.get("sender")
+    closer = sender.get("login") if isinstance(sender, dict) else None
+    approvers = {str(login).lower() for login in config.get("approvers", []) if isinstance(login, str)}
+    if not isinstance(closer, str) or closer.lower() not in approvers:
+        raise ValueError("boundary issue was not closed by an approved maintainer")
+    closed_by = issue.get("closed_by")
+    if isinstance(closed_by, dict) and isinstance(closed_by.get("login"), str) and closed_by["login"].lower() != closer.lower():
+        raise ValueError("boundary issue closer does not match the workflow actor")
+    bots = {str(login).lower() for login in config.get("submissionBots", []) if isinstance(login, str)}
+    if actor_login(issue).lower() not in bots:
+        raise ValueError("boundary issue was not created by the submission App")
+    number = issue.get("number")
+    if not isinstance(number, int) or isinstance(number, bool) or number < 1:
+        raise ValueError("boundary issue number is invalid")
+    expected_url = f"https://github.com/{config.get('repository', '')}/issues/{number}"
+    issue_url = str(issue.get("html_url") or issue.get("url") or "")
+    if issue_url != expected_url:
+        raise ValueError("boundary issue URL is not canonical")
+    reviewed_at = str(issue.get("closed_at", ""))[:10]
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", reviewed_at):
+        raise ValueError("boundary issue closure time is unavailable")
+    return issue, number, issue_url, reviewed_at
+
+
+def membership_rows(path: Path) -> tuple[list[dict[str, str]], dict[str, dict[str, str]]]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    required = {"DGUID", "PRUID", "CSDUID", "leaf_tag"}
+    if not rows or not required.issubset(rows[0]):
+        raise ValueError("authoritative membership is missing required columns")
+    by_dguid: dict[str, dict[str, str]] = {}
+    for row in rows:
+        dguid = str(row["DGUID"])
+        if not dguid or dguid in by_dguid:
+            raise ValueError("authoritative membership has an empty or duplicate DGUID")
+        by_dguid[dguid] = row
+    return rows, by_dguid
+
+
+def province_anchor_tags(
+    cells_dir: Path,
+    pruid: str,
+    by_dguid: dict[str, dict[str, str]],
+    leaves: set[str],
+    jurisdictions: dict[str, str],
+) -> dict[str, str]:
+    path = cells_dir / f"cells-{pruid}.topo.json"
+    topology = read_json(path)
+    try:
+        geometries = topology["objects"]["cells"]["geometries"]
+    except (KeyError, TypeError) as exc:
+        raise ValueError(f"cell authority is invalid for province {pruid}") from exc
+    if not isinstance(topology, dict) or topology.get("type") != "Topology" or not isinstance(geometries, list):
+        raise ValueError(f"cell authority is invalid for province {pruid}")
+    seen: set[str] = set()
+    anchors: dict[str, str] = {}
+    counts: Counter[str] = Counter()
+    for geometry in geometries:
+        props = geometry.get("properties") if isinstance(geometry, dict) else None
+        if not isinstance(props, dict):
+            raise ValueError(f"cell authority is invalid for province {pruid}")
+        dguid = str(props.get("DGUID", "")).strip()
+        row = by_dguid.get(dguid)
+        cell_pruid = str(props.get("PRUID", "")).strip().zfill(2)
+        cell_leaf = str(props.get("leaf_tag", "")).strip()
+        if (
+            not dguid
+            or dguid in seen
+            or row is None
+            or str(row["PRUID"]).zfill(2) != pruid
+            or cell_pruid != pruid
+            or cell_leaf != row["leaf_tag"]
+        ):
+            raise ValueError(f"cell authority disagrees with membership for province {pruid}")
+        seen.add(dguid)
+        seed = str(props.get("seed_tag", "")).strip()
+        if seed:
+            if seed != cell_leaf or seed not in leaves or jurisdictions.get(seed) != PR_TO_TAG[pruid]:
+                raise ValueError(f"cell authority contains an invalid anchor for province {pruid}")
+            anchors[dguid] = seed
+            counts[seed] += 1
+    expected_dguids = {
+        dguid for dguid, row in by_dguid.items()
+        if str(row["PRUID"]).zfill(2) == pruid
+    }
+    expected_leaves = {
+        leaf for leaf in leaves
+        if jurisdictions.get(leaf) == PR_TO_TAG[pruid]
+    }
+    if seen != expected_dguids or set(counts) != expected_leaves or any(count != 1 for count in counts.values()):
+        raise ValueError(f"cell authority has incomplete anchors for province {pruid}")
+    return anchors
+
+
+def validate_proposal(
+    proposal: Any,
+    payload: bytes,
+    proposal_hash: str,
+    membership_path: Path,
+    catalog_path: Path,
+    cells_dir: Path,
+) -> tuple[list[dict[str, str]], list[dict[str, str]], dict[str, str]]:
+    allowed = {"schema", "baseMembershipSha256", "submittedBy", "reason", "changes"}
+    if not isinstance(proposal, dict) or proposal.get("schema") != PROPOSAL_SCHEMA or set(proposal) - allowed:
+        raise ValueError("submission payload is not a region proposal")
+    if canonical_bytes(proposal) != payload or hashlib.sha256(payload).hexdigest() != proposal_hash:
+        raise ValueError("submission payload is not canonical or does not match its hash")
+    claimed_base = proposal.get("baseMembershipSha256")
+    if not isinstance(claimed_base, str) or not SHA256_RE.fullmatch(claimed_base) or claimed_base != file_sha256(membership_path):
+        raise ValueError("boundary proposal is stale for the current membership")
+    reason = proposal.get("reason")
+    if not isinstance(reason, str) or not reason.strip() or len(reason) > 1000:
+        raise ValueError("boundary proposal reason is invalid")
+    catalog = read_json(catalog_path)
+    if not isinstance(catalog, dict):
+        raise ValueError("region catalog is invalid")
+    leaves, jurisdictions = catalog_leaves(catalog)
+    rows, by_dguid = membership_rows(membership_path)
+    changes = proposal.get("changes")
+    if not isinstance(changes, list) or not changes:
+        raise ValueError("boundary proposal has no changes")
+    requested: dict[str, str] = {}
+    provinces: set[str] = set()
+    for change in changes:
+        if not isinstance(change, dict) or set(change) != {"DGUID", "from", "to"}:
+            raise ValueError("boundary proposal contains an invalid change")
+        dguid, from_tag, to_tag = change.get("DGUID"), change.get("from"), change.get("to")
+        if not all(isinstance(value, str) and value for value in (dguid, from_tag, to_tag)) or dguid in requested:
+            raise ValueError("boundary proposal contains an incomplete or duplicate change")
+        row = by_dguid.get(dguid)
+        if not row or row["leaf_tag"] != from_tag or from_tag == to_tag:
+            raise ValueError("boundary proposal is stale or contains a no-op")
+        pruid = str(row["PRUID"]).zfill(2)
+        if to_tag not in leaves or jurisdictions.get(to_tag) != PR_TO_TAG.get(pruid):
+            raise ValueError("boundary proposal crosses a province or territory")
+        provinces.add(pruid)
+        requested[dguid] = to_tag
+    if len(provinces) != 1:
+        raise ValueError("boundary proposal must affect exactly one province or territory")
+    pruid = next(iter(provinces))
+    anchors = province_anchor_tags(cells_dir, pruid, by_dguid, leaves, jurisdictions)
+    for dguid, to_tag in requested.items():
+        protected = anchors.get(dguid)
+        if protected and to_tag != protected:
+            raise ValueError("boundary proposal moves a current region anchor")
+    return rows, list(changes), requested
+
+
+def already_recorded(overrides: dict[str, Any], issue_url: str) -> bool:
+    records = list(overrides.get("cohortOverrides", [])) + list(overrides.get("splitExceptions", []))
+    return any(isinstance(record, dict) and record.get("sourceIssue") == issue_url for record in records)
+
+
+def record_decision(overrides: dict[str, Any], rows: list[dict[str, str]], requested: dict[str, str], reason: str, issue_number: int, issue_url: str, reviewed_at: str, approved_by: str) -> list[str]:
+    if overrides.get("schema") != OVERRIDES_SCHEMA or overrides.get("censusVintage") != 2021 or not isinstance(overrides.get("cohortOverrides"), list) or not isinstance(overrides.get("splitExceptions"), list):
+        raise ValueError("municipal override authority is invalid")
+    rows_by_csd: dict[str, list[dict[str, str]]] = defaultdict(list)
+    row_by_dguid: dict[str, dict[str, str]] = {}
+    for row in rows:
+        rows_by_csd[str(row["CSDUID"])].append(row)
+        row_by_dguid[str(row["DGUID"])] = row
+    touched = sorted({str(row_by_dguid[dguid]["CSDUID"]) for dguid in requested})
+    cohort = [record for record in overrides["cohortOverrides"] if not (isinstance(record, dict) and str(record.get("level", "")).upper() == "CSD" and str(record.get("id", "")) in touched)]
+    splits = [record for record in overrides["splitExceptions"] if not (isinstance(record, dict) and str(record.get("csduid", "")) in touched)]
+    common = {
+        "status": "approved",
+        "decision": f"Approved boundary update #{issue_number}.",
+        "evidence": [reason, issue_url],
+        "reviewedAt": reviewed_at,
+        "approvedBy": approved_by,
+        "sourceIssue": issue_url,
+    }
+    for csduid in touched:
+        csd_rows = sorted(rows_by_csd[csduid], key=lambda row: row["DGUID"])
+        final = {row["DGUID"]: requested.get(row["DGUID"], row["leaf_tag"]) for row in csd_rows}
+        owners = sorted(set(final.values()))
+        if len(owners) == 1:
+            cohort.append({"level": "CSD", "id": csduid, "leafTag": owners[0], **common})
+        else:
+            splits.append({
+                "csduid": csduid,
+                **common,
+                "members": [{"dguid": dguid, "leafTag": final[dguid]} for dguid in sorted(final)],
+            })
+    overrides["cohortOverrides"] = sorted(cohort, key=lambda record: (str(record.get("level", "")).upper(), str(record.get("id", ""))))
+    overrides["splitExceptions"] = sorted(splits, key=lambda record: str(record.get("csduid", "")))
+    return touched
+
+
+def update_source_lock(lock: dict[str, Any], override_payload: bytes) -> None:
+    sources = lock.get("sources")
+    if not isinstance(sources, list):
+        raise ValueError("region source lock is invalid")
+    matches = [source for source in sources if isinstance(source, dict) and source.get("id") == SOURCE_ID]
+    if len(matches) != 1:
+        raise ValueError("region source lock has no unique municipal override record")
+    matches[0]["bytes"] = len(override_payload)
+    matches[0]["sha256"] = hashlib.sha256(override_payload).hexdigest()
+
+
+def write_result(result: dict[str, Any], summary_path: Path | None, github_output: Path | None) -> None:
+    if summary_path:
+        write_atomic(summary_path, pretty_bytes(result))
+    if github_output:
+        lines = [
+            f"issue_number={result['issueNumber']}",
+            f"issue_url={result['issueUrl']}",
+            f"change_count={result['changeCount']}",
+            f"touched_csds={','.join(result['touchedCensusSubdivisions'])}",
+            f"already_applied={str(result['alreadyApplied']).lower()}",
+        ]
+        with github_output.open("a", encoding="utf-8", newline="\n") as handle:
+            handle.write("\n".join(lines) + "\n")
+    print(json.dumps(result, sort_keys=True))
+
+
+def main() -> None:
+    args = parse_args()
+    event, comments, config = read_json(args.event), flatten_comments(read_json(args.comments)), read_json(args.config)
+    if not isinstance(event, dict) or not isinstance(config, dict):
+        raise ValueError("automation event or configuration is invalid")
+    issue, issue_number, issue_url, reviewed_at = validate_event(event, config)
+    body = str(issue.get("body", ""))
+    schema = single_marker(body, "submission schema", r"<!-- submission-schema:([^ >]+) -->")
+    if schema != PROPOSAL_SCHEMA:
+        raise ValueError("closed issue is not a region proposal")
+    proposal_hash = single_marker(body, "submission hash", r"<!-- submission-sha256:([0-9a-f]{64}) -->")
+    signature_text = single_marker(body, "submission signature", r"<!-- submission-signature-rs256:([A-Za-z0-9_-]+) -->")
+    bots = {str(login).lower() for login in config.get("submissionBots", []) if isinstance(login, str)}
+    payload = extract_payload(body, comments, proposal_hash, bots)
+    verify_signature(
+        args.public_key,
+        f"{SIGNATURE_DOMAIN}:{schema}:{proposal_hash}".encode("ascii"),
+        decode_base64url(signature_text),
+    )
+    proposal = json.loads(payload)
+    overrides = read_json(args.overrides)
+    if not isinstance(overrides, dict):
+        raise ValueError("municipal override authority is invalid")
+    if already_recorded(overrides, issue_url):
+        result = {
+            "schema": "mcc-region-boundary-application/v1",
+            "issueNumber": issue_number,
+            "issueUrl": issue_url,
+            "changeCount": len(proposal.get("changes", [])) if isinstance(proposal, dict) else 0,
+            "touchedCensusSubdivisions": [],
+            "alreadyApplied": True,
+        }
+        write_result(result, args.summary, args.github_output)
+        return
+    rows, changes, requested = validate_proposal(
+        proposal,
+        payload,
+        proposal_hash,
+        args.membership,
+        args.catalog,
+        args.cells_dir,
+    )
+    touched = record_decision(
+        overrides, rows, requested, str(proposal["reason"]), issue_number,
+        issue_url, reviewed_at, str(event["sender"]["login"]),
+    )
+    override_payload = pretty_bytes(overrides)
+    source_lock = read_json(args.sources_lock)
+    if not isinstance(source_lock, dict):
+        raise ValueError("region source lock is invalid")
+    update_source_lock(source_lock, override_payload)
+    write_atomic(args.overrides, override_payload)
+    write_atomic(args.sources_lock, pretty_bytes(source_lock))
+    write_result({
+        "schema": "mcc-region-boundary-application/v1",
+        "issueNumber": issue_number,
+        "issueUrl": issue_url,
+        "changeCount": len(changes),
+        "touchedCensusSubdivisions": touched,
+        "alreadyApplied": False,
+    }, args.summary, args.github_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch-locked-region-sources.py
+++ b/scripts/fetch-locked-region-sources.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Download and verify the five locked Statistics Canada boundary archives."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import urllib.request
+import zipfile
+from pathlib import Path, PurePosixPath
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCES = {
+    "statcan-da-digital-2021": "digital_da",
+    "statcan-da-cartographic-2021": "cartographic_da",
+    "statcan-economic-regions-digital-2021": "economic_regions",
+    "statcan-census-divisions-digital-2021": "census_divisions",
+    "statcan-census-subdivisions-digital-2021": "census_subdivisions",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--lock",
+        type=Path,
+        default=ROOT / "docs" / "assets" / "regions" / "sources.lock.json",
+    )
+    parser.add_argument("--cache-dir", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--github-output", type=Path)
+    return parser.parse_args()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def download(source: dict, destination: Path) -> None:
+    expected_hash = str(source.get("sha256", ""))
+    expected_bytes = int(source.get("bytes", -1))
+    if (
+        destination.is_file()
+        and destination.stat().st_size == expected_bytes
+        and file_sha256(destination) == expected_hash
+    ):
+        return
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.tmp")
+    temporary.unlink(missing_ok=True)
+    request = urllib.request.Request(
+        str(source["url"]),
+        headers={"User-Agent": "MeshCore-Canada-region-generator/1"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=90) as response, temporary.open("wb") as output:
+            shutil.copyfileobj(response, output, length=1024 * 1024)
+        if temporary.stat().st_size != expected_bytes:
+            raise ValueError(f"downloaded byte count differs for {source['id']}")
+        if file_sha256(temporary) != expected_hash:
+            raise ValueError(f"downloaded SHA-256 differs for {source['id']}")
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def safe_extract(archive: Path, destination: Path, expected_hash: str) -> Path:
+    marker = destination / ".archive.sha256"
+    if marker.is_file() and marker.read_text(encoding="ascii").strip() == expected_hash:
+        shapefiles = sorted(destination.rglob("*.shp"))
+        if len(shapefiles) == 1:
+            return shapefiles[0]
+    if destination.exists():
+        shutil.rmtree(destination)
+    temporary = destination.with_name(f".{destination.name}.tmp")
+    if temporary.exists():
+        shutil.rmtree(temporary)
+    temporary.mkdir(parents=True)
+    try:
+        with zipfile.ZipFile(archive) as handle:
+            for info in handle.infolist():
+                member = PurePosixPath(info.filename)
+                if member.is_absolute() or ".." in member.parts:
+                    raise ValueError(f"unsafe ZIP path in {archive.name}")
+                target = temporary.joinpath(*member.parts)
+                if info.is_dir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with handle.open(info) as source, target.open("wb") as output:
+                    shutil.copyfileobj(source, output)
+        shapefiles = sorted(temporary.rglob("*.shp"))
+        if len(shapefiles) != 1:
+            raise ValueError(f"{archive.name} must contain exactly one shapefile")
+        (temporary / ".archive.sha256").write_text(expected_hash + "\n", encoding="ascii")
+        os.replace(temporary, destination)
+    finally:
+        if temporary.exists():
+            shutil.rmtree(temporary)
+    shapefiles = sorted(destination.rglob("*.shp"))
+    if len(shapefiles) != 1:
+        raise ValueError(f"{archive.name} extraction is incomplete")
+    return shapefiles[0]
+
+
+def main() -> None:
+    args = parse_args()
+    with args.lock.open(encoding="utf-8") as handle:
+        lock = json.load(handle)
+    records = {
+        str(source.get("id")): source
+        for source in lock.get("sources", [])
+        if isinstance(source, dict)
+    }
+    if set(SOURCES) - set(records):
+        raise ValueError("source lock is missing a required Statistics Canada archive")
+    args.cache_dir.mkdir(parents=True, exist_ok=True)
+    resolved: dict[str, str] = {}
+    for source_id, output_name in SOURCES.items():
+        source = records[source_id]
+        if not isinstance(source.get("url"), str) or not isinstance(source.get("file"), str):
+            raise ValueError(f"source lock record is incomplete for {source_id}")
+        archive = args.cache_dir / "archives" / source["file"]
+        download(source, archive)
+        shapefile = safe_extract(
+            archive,
+            args.cache_dir / "extracted" / source_id,
+            str(source["sha256"]),
+        )
+        resolved[output_name] = str(shapefile.resolve())
+    if args.manifest:
+        args.manifest.parent.mkdir(parents=True, exist_ok=True)
+        args.manifest.write_text(
+            json.dumps(resolved, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8", newline="\n") as handle:
+            for name, path in sorted(resolved.items()):
+                if "\n" in path or "\r" in path:
+                    raise ValueError("resolved source path contains a newline")
+                handle.write(f"{name}={path}\n")
+    print(json.dumps(resolved, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/automation/test_region_boundary_automation.py
+++ b/tests/automation/test_region_boundary_automation.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import base64
+import gzip
+import hashlib
+import importlib.util
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_script(name: str):
+    path = ROOT / "scripts" / name
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+apply_issue = load_script("apply-approved-region-issue.py")
+fetch_sources = load_script("fetch-locked-region-sources.py")
+
+
+def encoded_payload(payload: bytes) -> str:
+    return base64.urlsafe_b64encode(
+        gzip.compress(payload, compresslevel=9, mtime=0)
+    ).rstrip(b"=").decode("ascii")
+
+
+class PayloadTests(unittest.TestCase):
+    def setUp(self):
+        self.proposal = {
+            "baseMembershipSha256": "a" * 64,
+            "changes": [{"DGUID": "2021S0512TEST0001", "from": "aaa", "to": "bbb"}],
+            "reason": "Keep the lake with the city.",
+            "schema": apply_issue.PROPOSAL_SCHEMA,
+        }
+        self.payload = apply_issue.canonical_bytes(self.proposal)
+        self.digest = hashlib.sha256(self.payload).hexdigest()
+        self.bots = {"meshcore-canada-submissions[bot]"}
+
+    def test_extracts_hidden_and_legacy_inline_payloads(self):
+        hidden = (
+            "<!-- submission-payload-gzip-base64url:"
+            + encoded_payload(self.payload)
+            + " -->"
+        )
+        self.assertEqual(
+            apply_issue.extract_payload(hidden, [], self.digest, self.bots),
+            self.payload,
+        )
+        legacy = "### Canonical proposal JSON\n\n```json\n" + self.payload.decode() + "\n```\n"
+        self.assertEqual(
+            apply_issue.extract_payload(legacy, [], self.digest, self.bots),
+            self.payload,
+        )
+
+    def test_extracts_hidden_chunk_payloads_from_the_submission_bot(self):
+        encoded = encoded_payload(self.payload)
+        midpoint = len(encoded) // 2
+        body = "<!-- submission-payload-chunks:2 -->"
+        comments = [
+            {
+                "user": {"login": "meshcore-canada-submissions[bot]"},
+                "body": (
+                    f"<!-- mcc-submission-chunk:{self.digest}:1/2 -->\n"
+                    f"<!-- submission-payload-chunk-gzip-base64url:{encoded[:midpoint]} -->"
+                ),
+            },
+            {
+                "user": {"login": "meshcore-canada-submissions[bot]"},
+                "body": (
+                    f"<!-- mcc-submission-chunk:{self.digest}:2/2 -->\n"
+                    f"<!-- submission-payload-chunk-gzip-base64url:{encoded[midpoint:]} -->"
+                ),
+            },
+        ]
+        self.assertEqual(
+            apply_issue.extract_payload(body, comments, self.digest, self.bots),
+            self.payload,
+        )
+        comments[1]["user"]["login"] = "attacker"
+        with self.assertRaisesRegex(ValueError, "submission App"):
+            apply_issue.extract_payload(body, comments, self.digest, self.bots)
+
+    def test_signature_verification_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            key = Path(temporary) / "public.pem"
+            key.write_text("public", encoding="ascii")
+            with mock.patch.object(apply_issue.shutil, "which", return_value="openssl"), mock.patch.object(
+                apply_issue.subprocess,
+                "run",
+                return_value=mock.Mock(returncode=1),
+            ):
+                with self.assertRaisesRegex(ValueError, "verification failed"):
+                    apply_issue.verify_signature(key, b"message", b"signature")
+
+
+class ApprovalTests(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            "schema": apply_issue.AUTOMATION_SCHEMA,
+            "label": "boundary-update",
+            "repository": "MeshCore-ca/MeshCore-Canada",
+            "approvers": ["MrAlders0n", "n30nex"],
+            "submissionBots": ["meshcore-canada-submissions[bot]"],
+        }
+        self.issue = {
+            "number": 47,
+            "html_url": "https://github.com/MeshCore-ca/MeshCore-Canada/issues/47",
+            "state": "closed",
+            "state_reason": "completed",
+            "closed_at": "2026-07-16T17:20:00Z",
+            "closed_by": {"login": "MrAlders0n"},
+            "user": {"login": "meshcore-canada-submissions[bot]"},
+            "labels": [{"name": "boundary-update"}],
+        }
+        self.event = {
+            "action": "closed",
+            "sender": {"login": "MrAlders0n"},
+            "issue": self.issue,
+        }
+
+    def test_completed_boundary_issue_from_approver_is_accepted(self):
+        _, number, url, date = apply_issue.validate_event(self.event, self.config)
+        self.assertEqual((number, url, date), (47, self.issue["html_url"], "2026-07-16"))
+
+    def test_rejection_and_unapproved_closer_are_ignored_fail_closed(self):
+        self.issue["state_reason"] = "not_planned"
+        with self.assertRaisesRegex(ValueError, "not closed as completed"):
+            apply_issue.validate_event(self.event, self.config)
+        self.issue["state_reason"] = "completed"
+        self.event["sender"]["login"] = "random-user"
+        with self.assertRaisesRegex(ValueError, "approved maintainer"):
+            apply_issue.validate_event(self.event, self.config)
+
+
+class ProposalValidationTests(unittest.TestCase):
+    def test_current_anchor_cannot_be_moved(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            membership = root / "membership.csv"
+            membership.write_text(
+                "DGUID,PRUID,CSDUID,leaf_tag\n"
+                "d1,35,3500001,aaa\n"
+                "d2,35,3500002,bbb\n"
+                "d3,35,3500001,aaa\n",
+                encoding="utf-8",
+            )
+            catalog = root / "catalog.json"
+            catalog.write_text(
+                """{
+  "hierarchy": {
+    "can": {"parent": null},
+    "on": {"parent": "can"},
+    "aaa": {"parent": "on"},
+    "bbb": {"parent": "on"}
+  }
+}
+""",
+                encoding="utf-8",
+            )
+            cells = root / "cells"
+            cells.mkdir()
+            (cells / "cells-35.topo.json").write_text(
+                """{
+  "type": "Topology",
+  "objects": {
+    "cells": {
+      "geometries": [
+        {"properties": {"DGUID": "d1", "PRUID": "35", "leaf_tag": "aaa", "seed_tag": "aaa"}},
+        {"properties": {"DGUID": "d2", "PRUID": "35", "leaf_tag": "bbb", "seed_tag": "bbb"}},
+        {"properties": {"DGUID": "d3", "PRUID": "35", "leaf_tag": "aaa", "seed_tag": ""}}
+      ]
+    }
+  }
+}
+""",
+                encoding="utf-8",
+            )
+
+            proposal = {
+                "schema": apply_issue.PROPOSAL_SCHEMA,
+                "baseMembershipSha256": apply_issue.file_sha256(membership),
+                "reason": "Keep the municipality intact.",
+                "changes": [{"DGUID": "d1", "from": "aaa", "to": "bbb"}],
+            }
+            payload = apply_issue.canonical_bytes(proposal)
+            with self.assertRaisesRegex(ValueError, "current region anchor"):
+                apply_issue.validate_proposal(
+                    proposal,
+                    payload,
+                    hashlib.sha256(payload).hexdigest(),
+                    membership,
+                    catalog,
+                    cells,
+                )
+
+            proposal["changes"] = [{"DGUID": "d3", "from": "aaa", "to": "bbb"}]
+            payload = apply_issue.canonical_bytes(proposal)
+            _, changes, requested = apply_issue.validate_proposal(
+                proposal,
+                payload,
+                hashlib.sha256(payload).hexdigest(),
+                membership,
+                catalog,
+                cells,
+            )
+            self.assertEqual(changes[0]["DGUID"], "d3")
+            self.assertEqual(requested, {"d3": "bbb"})
+
+
+class DecisionTests(unittest.TestCase):
+    def setUp(self):
+        self.rows = [
+            {"DGUID": "d1", "PRUID": "35", "CSDUID": "3500001", "leaf_tag": "aaa"},
+            {"DGUID": "d2", "PRUID": "35", "CSDUID": "3500001", "leaf_tag": "aaa"},
+            {"DGUID": "d3", "PRUID": "35", "CSDUID": "3500001", "leaf_tag": "aaa"},
+        ]
+
+    @staticmethod
+    def overrides():
+        return {
+            "schema": apply_issue.OVERRIDES_SCHEMA,
+            "censusVintage": 2021,
+            "cohortOverrides": [],
+            "splitExceptions": [],
+        }
+
+    def test_partial_csd_change_becomes_complete_split_exception(self):
+        overrides = self.overrides()
+        touched = apply_issue.record_decision(
+            overrides,
+            self.rows,
+            {"d1": "bbb"},
+            "The shoreline belongs with the neighbouring city.",
+            47,
+            "https://github.com/MeshCore-ca/MeshCore-Canada/issues/47",
+            "2026-07-16",
+            "MrAlders0n",
+        )
+        self.assertEqual(touched, ["3500001"])
+        split = overrides["splitExceptions"][0]
+        self.assertEqual(
+            split["members"],
+            [
+                {"dguid": "d1", "leafTag": "bbb"},
+                {"dguid": "d2", "leafTag": "aaa"},
+                {"dguid": "d3", "leafTag": "aaa"},
+            ],
+        )
+        self.assertEqual(split["sourceIssue"].rsplit("/", 1)[-1], "47")
+
+    def test_whole_csd_change_becomes_csd_override(self):
+        overrides = self.overrides()
+        apply_issue.record_decision(
+            overrides,
+            self.rows,
+            {"d1": "bbb", "d2": "bbb", "d3": "bbb"},
+            "Keep the municipality together.",
+            48,
+            "https://github.com/MeshCore-ca/MeshCore-Canada/issues/48",
+            "2026-07-16",
+            "n30nex",
+        )
+        self.assertEqual(overrides["splitExceptions"], [])
+        self.assertEqual(
+            {key: overrides["cohortOverrides"][0][key] for key in ("level", "id", "leafTag")},
+            {"level": "CSD", "id": "3500001", "leafTag": "bbb"},
+        )
+
+    def test_source_lock_tracks_new_override_bytes(self):
+        lock = {"sources": [{"id": apply_issue.SOURCE_ID, "bytes": 0, "sha256": "0" * 64}]}
+        payload = b"updated overrides\n"
+        apply_issue.update_source_lock(lock, payload)
+        self.assertEqual(lock["sources"][0]["bytes"], len(payload))
+        self.assertEqual(lock["sources"][0]["sha256"], hashlib.sha256(payload).hexdigest())
+
+
+class SourceFetchTests(unittest.TestCase):
+    def test_locked_archive_download_and_safe_extract(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source_archive = root / "source.zip"
+            with zipfile.ZipFile(source_archive, "w") as archive:
+                archive.writestr("shape/test.shp", b"shape")
+                archive.writestr("shape/test.dbf", b"table")
+            source = {
+                "id": "test",
+                "url": source_archive.as_uri(),
+                "bytes": source_archive.stat().st_size,
+                "sha256": fetch_sources.file_sha256(source_archive),
+            }
+            cached = root / "cache" / "source.zip"
+            fetch_sources.download(source, cached)
+            self.assertEqual(fetch_sources.file_sha256(cached), source["sha256"])
+            shapefile = fetch_sources.safe_extract(cached, root / "extracted", source["sha256"])
+            self.assertEqual(shapefile.read_bytes(), b"shape")
+
+    def test_zip_traversal_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            archive_path = root / "bad.zip"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr("../outside.shp", b"bad")
+            with self.assertRaisesRegex(ValueError, "unsafe ZIP"):
+                fetch_sources.safe_extract(archive_path, root / "extract", "a" * 64)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/region-proposal-gateway/README.md
+++ b/tools/region-proposal-gateway/README.md
@@ -13,8 +13,10 @@ https://api.meshcore.ca:21323/api/meshcore-canada/submissions
 ```
 
 The service never changes repository contents or region authority. It creates
-fixed-format `enhancement` issues in `MeshCore-ca/MeshCore-Canada`; maintainers
-review and apply accepted work through the normal repository process.
+fixed-format issues in `MeshCore-ca/MeshCore-Canada`. Boundary proposals also
+receive `boundary-update`; after public review, a repository-owned GitHub
+Action applies only a proposal closed as **Completed** by an allowlisted
+maintainer.
 
 See the repository-root [`instructions.md`](../../instructions.md) for the
 copyable administrator activation, merge, verification, and rollback runbook.
@@ -79,7 +81,9 @@ The server revalidates every boundary proposal against the mounted authority:
 
 Changed authority files reload atomically. Invalid or mismatched authority
 fails closed. Large canonical boundary payloads use deterministic gzip plus
-base64url issue-comment chunks; retries resume only missing valid chunks.
+base64url issue-comment chunks; retries resume only missing valid chunks. The
+canonical boundary payload is stored in machine-readable HTML comments instead
+of adding a large JSON block to the public review text.
 
 ## GitHub App and Turnstile
 
@@ -94,6 +98,21 @@ The service signs a short-lived RS256 App JWT with `openssl`, requests an
 installation token restricted again to that repository and `issues: write`,
 and rejects broader returned scope. No App token or private key reaches a
 browser. Do not replace this with a personal access token.
+
+The approval Action is deliberately separate from the public service. It uses
+the matching public key in the repository secret
+`MCC_SUBMISSION_PUBLIC_KEY_PEM` to verify the signed proposal. The public key
+cannot create signatures, and the App still has no Contents permission.
+`.github/region-boundary-automation.json` contains the exact label, App
+identities, and maintainer allowlist.
+
+An accepted boundary issue must be App-authored, carry `boundary-update`, and
+be closed as **Completed** by an allowlisted maintainer. The Action rechecks the
+signature, current authority, and jurisdiction; records the reviewed census
+override; regenerates and validates the national layer; commits to `main`;
+and explicitly queues the Pages deployment. **Close as not planned** rejects a
+proposal without applying it. Verification or generation failure reopens the
+issue and leaves `main` unchanged.
 
 The Turnstile widget must be held in a MeshCore Canada account and allow
 `meshcore.ca` and `config.meshcore.ca`. Siteverify must return `success`, an
@@ -180,8 +199,9 @@ curl -si -H 'Origin: https://example.invalid' "$API/config"
 
 Expect HTTP 200 config, action `meshcore_submission`, exact allowed-origin
 CORS, HTTP 204 preflight, and denial without an allow-origin header for the
-invalid origin. The root runbook requires this branch deployment to pass before
-PR #39 is merged, followed by signed-out live tests of both forms.
+invalid origin. The root runbook requires the branch deployment to pass before
+the reviewed pull request is merged, followed by signed-out live tests of both
+forms and a not-planned boundary rejection test.
 
 ## Idempotency, recovery, and backups
 
@@ -215,6 +235,7 @@ No live credentials or third-party Python packages are required:
 
 ```sh
 python -m unittest discover -s tools/region-proposal-gateway/tests -v
+python -m unittest discover -s tests/automation -v
 node --test tests/editor/*.test.mjs
 python scripts/validate_community_submission.py
 ```
@@ -222,4 +243,6 @@ python scripts/validate_community_submission.py
 The suites cover both schemas, authority reload, canonical hashes, exact
 CORS/HTTP behavior, Turnstile hostname/action checks, least-privilege App
 tokens, safe issue rendering, idempotency, URL validation, and resumable
-large-payload comments.
+large-payload comments. The automation suite also covers approval gates,
+signature-bound payload extraction, source locking, safe archive extraction,
+and complete CSD/split decision recording.

--- a/tools/region-proposal-gateway/gateway.py
+++ b/tools/region-proposal-gateway/gateway.py
@@ -46,6 +46,7 @@ GITHUB_OWNER = "MeshCore-ca"
 GITHUB_REPO = "MeshCore-Canada"
 GITHUB_FULL_NAME = f"{GITHUB_OWNER}/{GITHUB_REPO}"
 GITHUB_LABEL = "enhancement"
+BOUNDARY_UPDATE_LABEL = "boundary-update"
 GITHUB_API_VERSION = "2026-03-10"
 MAX_BODY_BYTES = 2 * 1024 * 1024
 MAX_CHANGES = 25_000
@@ -850,7 +851,12 @@ class GitHubAppClient:
                     )
                 status, _, result = self._call(
                     "POST", f"/repos/{GITHUB_OWNER}/{GITHUB_REPO}/issues",
-                    {"title": title, "body": issue_body, "labels": [GITHUB_LABEL]},
+                    {
+                        "title": title,
+                        "body": issue_body,
+                        "labels": [GITHUB_LABEL]
+                        + ([BOUNDARY_UPDATE_LABEL] if schema == PROPOSAL_SCHEMA else []),
+                    },
                     return_definitive_client_error=True,
                 )
                 if status != 201 or not isinstance(result, dict) or not _is_int(result.get("number")):
@@ -939,7 +945,7 @@ class GitHubAppClient:
 
 def build_chunk_comment(proposal_hash: str, index: int, total: int, chunk: str) -> str:
     marker = f"<!-- mcc-submission-chunk:{proposal_hash}:{index}/{total} -->"
-    return f"{marker}\nCanonical submission payload chunk {index}/{total} (`gzip+base64url`, padding omitted):\n\n```text\n{chunk}\n```\n"
+    return f"{marker}\n<!-- submission-payload-chunk-gzip-base64url:{chunk} -->\n"
 
 
 def build_region_issue(
@@ -971,21 +977,20 @@ def build_region_issue(
         f"<p>{reason}</p>\n\n"
         "### Moves\n\n"
         f"{move_lines}\n\n"
+        "_Maintainers: close this issue as **Completed** to approve it, or **Not planned** to reject it._\n\n"
     )
+    compressed = gzip.compress(canonical_bytes, compresslevel=9, mtime=0)
+    encoded_payload = _b64url(compressed)
     chunked = len(canonical_bytes) > INLINE_CANONICAL_BYTES
-    inline_body = ""
+    inline_body = common + f"<!-- submission-payload-gzip-base64url:{encoded_payload} -->\n"
     if not chunked:
-        inline_body = common + "### Canonical proposal JSON\n\n" + _json_fence(canonical_bytes.decode("utf-8"))
         chunked = len(inline_body.encode("utf-8")) > MAX_ISSUE_BODY_BYTES
     if not chunked:
         body = inline_body
     else:
-        compressed = gzip.compress(canonical_bytes, compresslevel=9, mtime=0)
-        chunks = (len(_b64url(compressed)) + COMMENT_CHUNK_CHARS - 1) // COMMENT_CHUNK_CHARS
+        chunks = (len(encoded_payload) + COMMENT_CHUNK_CHARS - 1) // COMMENT_CHUNK_CHARS
         body = common + (
-            "### Canonical proposal JSON\n\n"
-            f"The exact canonical JSON is stored in **{chunks}** ordered issue comment(s) as deterministic "
-            "`gzip+base64url` data. Base64 padding is omitted. The gateway resumes any missing chunks on retry.\n"
+            f"<!-- submission-payload-chunks:{chunks} -->\n"
         )
     if len(body.encode("utf-8")) > MAX_ISSUE_BODY_BYTES:
         raise UpstreamError("issue_body_too_large")

--- a/tools/region-proposal-gateway/tests/test_gateway.py
+++ b/tools/region-proposal-gateway/tests/test_gateway.py
@@ -318,12 +318,14 @@ class GitHubTests(unittest.TestCase):
         token_call = transport.calls[0]
         self.assertEqual(token_call[3], {"permissions": {"issues": "write"}, "repositories": ["MeshCore-Canada"]})
         issue_call = next(call for call in transport.calls if call[1].endswith("/issues"))
-        self.assertEqual(issue_call[3]["labels"], ["enhancement"])
+        self.assertEqual(issue_call[3]["labels"], ["enhancement", "boundary-update"])
         body = issue_call[3]["body"]
         self.assertIn("submission-sha256:" + digest, body)
         self.assertIn("@\u200bteam", body)
-        self.assertNotIn("<script>", body.split("### Canonical proposal JSON", 1)[0])
-        self.assertIn("````json", body)  # dynamic fence encloses user backticks
+        self.assertNotIn("<script>", body)
+        self.assertNotIn("Canonical proposal JSON", body)
+        self.assertIn("submission-payload-gzip-base64url:", body)
+        self.assertIn("close this issue as **Completed**", body)
         self.assertNotIn("contents", json.dumps(transport.calls).lower())
 
     def test_duplicate_search_returns_existing_issue_without_create(self):


### PR DESCRIPTION
## Summary

- add `boundary-update` to future App-created boundary proposals while leaving community ideas unchanged
- apply a proposal only when an allowlisted maintainer closes its labelled issue as Completed
- keep the public GitHub App issues-only; the repository Action owns write authority
- verify the App author, closer, label, signed canonical payload, current membership, jurisdiction, and current anchor cells
- record reviewed whole-CSD or complete DA split decisions, regenerate the national authority from locked sources, validate it, commit to `main`, and explicitly queue the Pages deployment
- hide the machine payload in issue markers so the public ticket stays readable
- document activation, rejection, recovery, and rollback

Close as not planned is a rejection and makes no authority change. A verification or generation failure publishes nothing and reopens the issue.

## One-time activation

The workflow must be merged onto `main` before a close event can trigger it.

- [x] Create the `boundary-update` label.
- [x] Keep the repository workflow default read-only and Action pull-request approval disabled; the boundary workflow declares only its required write scopes.
- [x] Confirm the approver allowlist in `.github/region-boundary-automation.json`.
- [ ] Add `MCC_SUBMISSION_PUBLIC_KEY_PEM`, derived from the production submission App PEM.
- [ ] Update the production gateway to the merged revision.

The GitHub App remains limited to Issues read/write and must not receive Contents permission. Full commands are in `instructions.md`.

## Consolidated boundary test

This retains the earlier production test proposal for review context only. It does not approve or apply a boundary change as part of this PR.

- Submitted by: `n30nex`
- Reason: Pushlinch Lake is part of Cambridge
- Requested move: `wel -> wat` for 2 dissemination areas
- DGUIDs: `2021S051235230403`, `2021S051235230404`
- Proposal SHA-256: `d66dc7ace3873898f2aae2abfc91b3b3acee6cfaec0c999bbf5af0ed38c85b7e`
- Base membership SHA-256: `9e23bf1605a32e469e651dd62c4ecf4ff6f7169da95f8d15fc82ad4fa53f9c87`
- Previous disposition: not planned; no authority change was made

## Validation

- gateway: 35 passed, 1 Windows-only skip
- approval automation: 11 passed
- editor: 39 passed
- national membership: 57,936 DAs, 193 leaves
- cartographic and digital partitions: 0 positive-area overlaps
- strict MkDocs build: passed
- actionlint: passed