### PR TITLE
Retry verified census source downloads

### DIFF
--- a/scripts/fetch-locked-region-sources.py
+++ b/scripts/fetch-locked-region-sources.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import http.client
 import json
 import os
 import shutil
+import sys
+import time
 import urllib.request
 import zipfile
 from pathlib import Path, PurePosixPath
@@ -21,6 +24,8 @@ SOURCES = {
     "statcan-census-divisions-digital-2021": "census_divisions",
     "statcan-census-subdivisions-digital-2021": "census_subdivisions",
 }
+DOWNLOAD_ATTEMPTS = 3
+DOWNLOAD_RETRY_DELAY_SECONDS = 1.0
 
 
 def parse_args() -> argparse.Namespace:
@@ -44,8 +49,18 @@ def file_sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def download(source: dict, destination: Path) -> None:
-    expected_hash = str(source.get("sha256", ""))
+def download(
+    source: dict,
+    destination: Path,
+    *,
+    attempts: int = DOWNLOAD_ATTEMPTS,
+    retry_delay_seconds: float = DOWNLOAD_RETRY_DELAY_SECONDS,
+) -> None:
+    if attempts < 1:
+        raise ValueError("download attempts must be at least one")
+    if retry_delay_seconds < 0:
+        raise ValueError("download retry delay cannot be negative")
+    expected_hash = str(source.get("sha256", "")).lower()
     expected_bytes = int(source.get("bytes", -1))
     if (
         destination.is_file()
@@ -56,20 +71,50 @@ def download(source: dict, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     temporary = destination.with_name(f".{destination.name}.tmp")
     temporary.unlink(missing_ok=True)
-    request = urllib.request.Request(
-        str(source["url"]),
-        headers={"User-Agent": "MeshCore-Canada-region-generator/1"},
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=90) as response, temporary.open("wb") as output:
-            shutil.copyfileobj(response, output, length=1024 * 1024)
-        if temporary.stat().st_size != expected_bytes:
-            raise ValueError(f"downloaded byte count differs for {source['id']}")
-        if file_sha256(temporary) != expected_hash:
-            raise ValueError(f"downloaded SHA-256 differs for {source['id']}")
-        os.replace(temporary, destination)
-    finally:
-        temporary.unlink(missing_ok=True)
+    for attempt in range(1, attempts + 1):
+        headers = {
+            "Accept-Encoding": "identity",
+            "User-Agent": "MeshCore-Canada-region-generator/1",
+        }
+        if attempt > 1:
+            headers["Cache-Control"] = "no-cache"
+        request = urllib.request.Request(str(source["url"]), headers=headers)
+        try:
+            with (
+                urllib.request.urlopen(request, timeout=90) as response,
+                temporary.open("wb") as output,
+            ):
+                shutil.copyfileobj(response, output, length=1024 * 1024)
+            actual_bytes = temporary.stat().st_size
+            if actual_bytes != expected_bytes:
+                raise ValueError(
+                    f"downloaded byte count differs for {source['id']}: "
+                    f"expected {expected_bytes}, got {actual_bytes}"
+                )
+            actual_hash = file_sha256(temporary)
+            if actual_hash != expected_hash:
+                raise ValueError(
+                    f"downloaded SHA-256 differs for {source['id']}: "
+                    f"expected {expected_hash}, got {actual_hash}"
+                )
+            os.replace(temporary, destination)
+            return
+        except (OSError, ValueError, http.client.HTTPException) as error:
+            temporary.unlink(missing_ok=True)
+            if attempt == attempts:
+                raise RuntimeError(
+                    f"failed to fetch and verify {source['id']} after "
+                    f"{attempts} attempts: {error}"
+                ) from error
+            print(
+                f"Fetch attempt {attempt}/{attempts} failed for "
+                f"{source['id']}: {error}; retrying",
+                file=sys.stderr,
+            )
+            if retry_delay_seconds:
+                time.sleep(retry_delay_seconds * (2 ** (attempt - 1)))
+        finally:
+            temporary.unlink(missing_ok=True)
 
 
 def safe_extract(archive: Path, destination: Path, expected_hash: str) -> Path:

--- a/tests/automation/test_region_boundary_automation.py
+++ b/tests/automation/test_region_boundary_automation.py
@@ -4,6 +4,7 @@ import base64
 import gzip
 import hashlib
 import importlib.util
+import io
 import tempfile
 import unittest
 import zipfile
@@ -302,6 +303,63 @@ class SourceFetchTests(unittest.TestCase):
             self.assertEqual(fetch_sources.file_sha256(cached), source["sha256"])
             shapefile = fetch_sources.safe_extract(cached, root / "extracted", source["sha256"])
             self.assertEqual(shapefile.read_bytes(), b"shape")
+
+    def test_download_retries_same_size_sha_mismatch(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            expected = b"good archive bytes"
+            corrupted = b"bad! archive bytes"
+            source = {
+                "id": "test",
+                "url": "https://example.invalid/source.zip",
+                "bytes": len(expected),
+                "sha256": hashlib.sha256(expected).hexdigest(),
+            }
+            destination = root / "cache" / "source.zip"
+            responses = [io.BytesIO(corrupted), io.BytesIO(expected)]
+            with mock.patch.object(
+                fetch_sources.urllib.request,
+                "urlopen",
+                side_effect=responses,
+            ) as urlopen:
+                fetch_sources.download(
+                    source,
+                    destination,
+                    retry_delay_seconds=0,
+                )
+            self.assertEqual(urlopen.call_count, 2)
+            self.assertEqual(destination.read_bytes(), expected)
+
+    def test_download_fails_closed_after_persistent_sha_mismatch(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            expected = b"good archive bytes"
+            corrupted = b"bad! archive bytes"
+            source = {
+                "id": "test",
+                "url": "https://example.invalid/source.zip",
+                "bytes": len(expected),
+                "sha256": hashlib.sha256(expected).hexdigest(),
+            }
+            destination = root / "cache" / "source.zip"
+
+            def corrupt_response(*_args, **_kwargs):
+                return io.BytesIO(corrupted)
+
+            with mock.patch.object(
+                fetch_sources.urllib.request,
+                "urlopen",
+                side_effect=corrupt_response,
+            ) as urlopen:
+                with self.assertRaisesRegex(RuntimeError, "after 3 attempts"):
+                    fetch_sources.download(
+                        source,
+                        destination,
+                        retry_delay_seconds=0,
+                    )
+            self.assertEqual(urlopen.call_count, 3)
+            self.assertFalse(destination.exists())
+            self.assertFalse((destination.parent / ".source.zip.tmp").exists())
 
     def test_zip_traversal_is_rejected(self):
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## What changed

- retry locked Statistics Canada source downloads up to three times when a request, byte-count check, or SHA-256 check fails
- request identity encoding and bypass caches on retry attempts
- report expected and observed integrity values while retaining fail-closed behavior
- add regression coverage for transient same-size corruption and persistent corruption

## Why

The approved two-cell boundary proposal in #50 passed all proposal checks, but run [29628811066](https://github.com/MeshCore-ca/MeshCore-Canada/actions/runs/29628811066) received a transient response whose SHA-256 did not match the locked Economic Regions archive. A fresh download still matches the recorded size and digest, so the source lock is valid; the single-attempt downloader was the failure point.

## Impact

A transient upstream or network corruption can recover automatically. No unverified archive is accepted: all attempts must still match both the locked byte count and SHA-256, and persistent mismatch remains a hard failure.

## Validation

- `python -m unittest discover -s tests/automation -v` (13 passed)
- `python -m py_compile scripts/fetch-locked-region-sources.py`
- `git diff --check`