### PR TITLE
Correct locked Economic Regions digest

### DIFF
--- a/docs/assets/regions/sources.lock.json
+++ b/docs/assets/regions/sources.lock.json
@@ -29,7 +29,7 @@
       "file": "ler_000a21a_e.zip",
       "bytes": 7021635,
       "lastModified": "2021-10-21T23:39:08Z",
-      "sha256": "d72e8839a7b3c4c77d67d9dcf568623fbbc8b1dadf74c74018306b2fca4a75",
+      "sha256": "d72e8839a7b3c4c77d67d9dcf568623fbbc8c8b1dadf74c74018306b2fca4a75",
       "licence": "Statistics Canada Open Licence"
     },
     {

--- a/tests/automation/test_region_boundary_automation.py
+++ b/tests/automation/test_region_boundary_automation.py
@@ -5,6 +5,7 @@ import gzip
 import hashlib
 import importlib.util
 import io
+import json
 import tempfile
 import unittest
 import zipfile
@@ -285,6 +286,23 @@ class DecisionTests(unittest.TestCase):
 
 
 class SourceFetchTests(unittest.TestCase):
+    def test_required_source_lock_digests_are_sha256(self):
+        lock_path = ROOT / "docs" / "assets" / "regions" / "sources.lock.json"
+        lock = json.loads(lock_path.read_text(encoding="utf-8"))
+        records = {
+            str(source.get("id")): source
+            for source in lock.get("sources", [])
+            if isinstance(source, dict)
+        }
+        for source_id in fetch_sources.SOURCES:
+            self.assertIn(source_id, records)
+            digest = str(records[source_id].get("sha256", ""))
+            self.assertRegex(
+                digest,
+                r"\A[0-9a-f]{64}\Z",
+                f"{source_id} must have a complete lowercase SHA-256 digest",
+            )
+
     def test_locked_archive_download_and_safe_extract(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## What changed

- correct the locked SHA-256 for Statistics Canada's 2021 Economic Regions archive
- validate that every required locked census source has a complete lowercase 64-character SHA-256 in the automation test suite

## Root cause

The lock recorded a 62-character digest:

`d72e8839a7b3c4c77d67d9dcf568623fbbc8b1dadf74c74018306b2fca4a75`

The verified 7,021,635-byte archive consistently hashes to:

`d72e8839a7b3c4c77d67d9dcf568623fbbc8c8b1dadf74c74018306b2fca4a75`

The missing `c8` caused both attempts of run [29628811066](https://github.com/MeshCore-ca/MeshCore-Canada/actions/runs/29628811066) to fail closed.

## Validation

- exact local archive size and SHA-256 match the corrected lock
- `python -m unittest discover -s tests/automation -v` (14 passed)
- `git diff --check`