### PR TITLE
Support cross-province and cross-border repeater paths

### DIFF
--- a/docs/analyzer/iata-codes.md
+++ b/docs/analyzer/iata-codes.md
@@ -31,7 +31,6 @@ Host-side helper scripts show this same quick list interactively when you omit `
     | YTR | Trenton / Quinte West |
     | YHD | Dryden |
     | YPL | Pickle Lake |
-    | YND | Gatineau (Ottawa area) |
 
 ??? note "Quebec"
 
@@ -40,6 +39,7 @@ Host-side helper scripts show this same quick list interactively when you omit `
     | YUL | Montreal (Trudeau) |
     | YMX | Montreal (Mirabel) |
     | YQB | Quebec City |
+    | YND | Gatineau (Ottawa area) |
     | YBG | Bagotville / Saguenay |
     | YVO | Val-d'Or |
     | YHU | Montreal (St-Hubert) |

--- a/docs/analyzer/scripts/add-meshcore-ca-broker.sh
+++ b/docs/analyzer/scripts/add-meshcore-ca-broker.sh
@@ -127,10 +127,10 @@ Ontario|YPQ|Peterborough
 Ontario|YTR|Trenton / Quinte West
 Ontario|YHD|Dryden
 Ontario|YPL|Pickle Lake
-Ontario|YND|Gatineau (Ottawa area)
 Quebec|YUL|Montreal (Trudeau)
 Quebec|YMX|Montreal (Mirabel)
 Quebec|YQB|Quebec City
+Quebec|YND|Gatineau (Ottawa area)
 Quebec|YBG|Bagotville / Saguenay
 Quebec|YVO|Val-d'Or
 Quebec|YHU|Montreal (St-Hubert)

--- a/docs/assets/regions/NOTICE.txt
+++ b/docs/assets/regions/NOTICE.txt
@@ -51,6 +51,28 @@ municipal-overrides.json records reviewed CD/CSD ownership decisions and any
 approved CSD split. A split must enumerate every affected Dissemination Area;
 an editor export or draft is not authoritative until reviewed and merged.
 
+Cross-province entries in canada-regions.json are non-geographic repeater
+configuration metadata. They join canonical member paths in generated commands
+without changing DA ownership or creating another boundary layer.
+
+Neighbouring U.S. entries are also non-geographic configuration metadata. They
+are optional, never selected from a map point, and never add U.S. geometry to
+the Canadian layer. Documented path names come from:
+
+https://wnymeshcore.org/guides/radio-settings
+https://gessaman.com/meshcore/regions/
+https://www.regionmesh.com/meshcore-region-configuration/
+
+Their 2026-07-18 trafficEvidence fields contain aggregate resolved-route
+pattern and observation counts from:
+
+https://dev.meshcore.ca/
+
+Only areas with observed Canada-U.S. routes are listed. The catalog retains no
+node identifiers, names, or exact coordinates. A route count supports review
+of an optional forwarding path; it is not a coverage guarantee or a boundary
+source.
+
 radio-density.json
 ------------------
 

--- a/docs/assets/regions/canada-regions.json
+++ b/docs/assets/regions/canada-regions.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026-07-13-strategy-v1.1.1",
+  "version": "2026-07-18-mcc-reg-1.1-proposed",
   "strategy": {
     "title": "Canada MeshCore Region Strategy",
     "version": "1.1.1",
@@ -20,7 +20,7 @@
   },
   "authority": {
     "standard": "MCC-REG-1",
-    "version": "1.0-proposed",
+    "version": "1.1-proposed",
     "document": "../../regions/standard/",
     "geographicModel": "exclusive-national-partition",
     "topologyAtom": "Statistics Canada 2021 Dissemination Area",
@@ -6602,7 +6602,12 @@
         "gatout"
       ],
       "geographic": false,
-      "emitInCommands": false
+      "emitInCommands": false,
+      "repeaterConfig": {
+        "mode": "shared-member-paths",
+        "defaultForMembers": true,
+        "basis": "continuous-cross-province-network"
+      }
     },
     "lloyd": {
       "label": "Lloydminster",
@@ -6611,7 +6616,186 @@
         "lloyd-sk"
       ],
       "geographic": false,
-      "emitInCommands": false
+      "emitInCommands": false,
+      "repeaterConfig": {
+        "mode": "shared-member-paths",
+        "defaultForMembers": true,
+        "basis": "single-cross-province-community"
+      }
+    }
+  },
+  "externalRegionPaths": {
+    "western-new-york": {
+      "label": "Western New York",
+      "country": "us",
+      "areaCode": "NY",
+      "path": [
+        "us",
+        "us-ny"
+      ],
+      "tagLabels": {
+        "us": "United States",
+        "us-ny": "New York"
+      },
+      "geographic": false,
+      "automatic": false,
+      "eligibility": "border-or-shared-water",
+      "authority": {
+        "status": "documented",
+        "source": "WNY MeshCore radio settings",
+        "sourceUrl": "https://wnymeshcore.org/guides/radio-settings"
+      },
+      "trafficEvidence": {
+        "source": "https://dev.meshcore.ca/",
+        "snapshot": "2026-07-18",
+        "method": "mixed-canada-us-resolved-route",
+        "routePatterns": 4508,
+        "observations": 33820
+      }
+    },
+    "washington": {
+      "label": "Washington",
+      "country": "us",
+      "areaCode": "WA",
+      "path": [
+        "west",
+        "pnw",
+        "wa"
+      ],
+      "tagLabels": {
+        "west": "Western mesh",
+        "pnw": "Pacific Northwest",
+        "wa": "Washington"
+      },
+      "geographic": false,
+      "automatic": false,
+      "eligibility": "border-or-shared-water",
+      "authority": {
+        "status": "documented",
+        "source": "Pacific Northwest MeshCore Region Strategy",
+        "sourceUrl": "https://gessaman.com/meshcore/regions/"
+      },
+      "trafficEvidence": {
+        "source": "https://dev.meshcore.ca/",
+        "snapshot": "2026-07-18",
+        "method": "mixed-canada-us-resolved-route",
+        "routePatterns": 5384,
+        "observations": 21596
+      }
+    },
+    "oregon": {
+      "label": "Oregon",
+      "country": "us",
+      "areaCode": "OR",
+      "path": [
+        "west",
+        "pnw",
+        "or"
+      ],
+      "tagLabels": {
+        "west": "Western mesh",
+        "pnw": "Pacific Northwest",
+        "or": "Oregon"
+      },
+      "geographic": false,
+      "automatic": false,
+      "eligibility": "observed-further-route",
+      "authority": {
+        "status": "documented",
+        "source": "Pacific Northwest MeshCore Region Strategy",
+        "sourceUrl": "https://gessaman.com/meshcore/regions/"
+      },
+      "trafficEvidence": {
+        "source": "https://dev.meshcore.ca/",
+        "snapshot": "2026-07-18",
+        "method": "mixed-canada-us-resolved-route",
+        "routePatterns": 903,
+        "observations": 1394
+      }
+    },
+    "pennsylvania": {
+      "label": "Pennsylvania",
+      "country": "us",
+      "areaCode": "PA",
+      "path": [
+        "us",
+        "us-pa"
+      ],
+      "tagLabels": {
+        "us": "United States",
+        "us-pa": "Pennsylvania"
+      },
+      "geographic": false,
+      "automatic": false,
+      "eligibility": "border-or-shared-water",
+      "authority": {
+        "status": "provisional",
+        "source": "RegionMesh state-path convention",
+        "sourceUrl": "https://www.regionmesh.com/meshcore-region-configuration/"
+      },
+      "trafficEvidence": {
+        "source": "https://dev.meshcore.ca/",
+        "snapshot": "2026-07-18",
+        "method": "mixed-canada-us-resolved-route",
+        "routePatterns": 37,
+        "observations": 82
+      }
+    },
+    "ohio": {
+      "label": "Ohio",
+      "country": "us",
+      "areaCode": "OH",
+      "path": [
+        "us",
+        "us-oh"
+      ],
+      "tagLabels": {
+        "us": "United States",
+        "us-oh": "Ohio"
+      },
+      "geographic": false,
+      "automatic": false,
+      "eligibility": "border-or-shared-water",
+      "authority": {
+        "status": "provisional",
+        "source": "RegionMesh state-path convention",
+        "sourceUrl": "https://www.regionmesh.com/meshcore-region-configuration/"
+      },
+      "trafficEvidence": {
+        "source": "https://dev.meshcore.ca/",
+        "snapshot": "2026-07-18",
+        "method": "mixed-canada-us-resolved-route",
+        "routePatterns": 6,
+        "observations": 10
+      }
+    },
+    "california": {
+      "label": "California",
+      "country": "us",
+      "areaCode": "CA",
+      "path": [
+        "west",
+        "ca"
+      ],
+      "tagLabels": {
+        "west": "Western mesh",
+        "ca": "California"
+      },
+      "geographic": false,
+      "automatic": false,
+      "eligibility": "observed-further-route",
+      "authority": {
+        "status": "provisional",
+        "source": "Pacific Northwest MeshCore Region Strategy future extension",
+        "sourceUrl": "https://gessaman.com/meshcore/regions/"
+      },
+      "trafficEvidence": {
+        "source": "https://dev.meshcore.ca/",
+        "snapshot": "2026-07-18",
+        "method": "mixed-canada-us-resolved-route",
+        "routePatterns": 7,
+        "observations": 12
+      }
     }
   },
   "retiredCanonicalTags": {

--- a/docs/assets/regions/regions.css
+++ b/docs/assets/regions/regions.css
@@ -352,6 +352,81 @@ body:has([data-mcc-regions]) .md-typeset a {
   background: var(--mcc-soft);
 }
 
+.mcc-chip.is-required {
+  cursor: default;
+}
+
+.mcc-chip-required {
+  color: var(--mcc-muted);
+  font-size: 0.62rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.mcc-served-region-groups {
+  display: grid;
+  gap: 0.7rem;
+  margin-top: 0.65rem;
+}
+
+.mcc-picker-heading {
+  margin: 0.9rem 0 0.15rem;
+  color: var(--mcc-text);
+  font-size: 0.86rem;
+}
+
+.mcc-add-region-label {
+  display: block;
+  margin-top: 0.8rem;
+}
+
+.mcc-neighbour-paths {
+  margin-top: 0.9rem;
+  padding-top: 0.1rem;
+  border-top: 1px solid var(--mcc-border);
+}
+
+.mcc-neighbour-path-list {
+  display: grid;
+  gap: 0.42rem;
+  margin-top: 0.6rem;
+}
+
+.mcc-neighbour-path {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.5rem;
+  align-items: start;
+  padding: 0.5rem 0.58rem;
+  border: 1px solid var(--mcc-border);
+  border-radius: 0.35rem;
+  background: var(--mcc-surface-2);
+  cursor: pointer;
+}
+
+.mcc-neighbour-path:hover,
+.mcc-neighbour-path:has(input:checked) {
+  border-color: var(--mcc-green);
+  background: var(--mcc-soft);
+}
+
+.mcc-neighbour-path input {
+  margin-top: 0.2rem;
+  accent-color: var(--mcc-green);
+}
+
+.mcc-neighbour-path span,
+.mcc-neighbour-path strong,
+.mcc-neighbour-path small {
+  display: block;
+}
+
+.mcc-neighbour-path small {
+  margin-top: 0.12rem;
+  color: var(--mcc-muted);
+  line-height: 1.35;
+}
+
 .mcc-status {
   margin-top: 0.55rem;
   padding: 0.5rem 0.65rem;
@@ -517,6 +592,37 @@ body:has([data-mcc-regions]) .md-typeset a {
   line-height: 1.45;
 }
 
+.mcc-region-path-list {
+  display: grid;
+  gap: 0.22rem;
+  margin-top: 0.3rem;
+}
+
+.mcc-region-path-list span {
+  display: block;
+}
+
+.mcc-shared-area-note {
+  display: grid;
+  gap: 0.18rem;
+  margin-top: 0.7rem;
+  padding: 0.62rem 0.7rem;
+  border: 1px solid color-mix(in srgb, var(--mcc-green), transparent 55%);
+  border-radius: 0.4rem;
+  background: color-mix(in srgb, var(--mcc-green), transparent 91%);
+}
+
+.mcc-shared-area-note strong {
+  color: var(--mcc-text);
+  font-size: 0.78rem;
+}
+
+.mcc-shared-area-note span {
+  color: var(--mcc-muted);
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
 .mcc-result-advanced {
   padding: 0.65rem 0.75rem;
   border: 1px solid var(--mcc-border);
@@ -605,6 +711,10 @@ body:has([data-mcc-regions]) .md-typeset a {
 
 .mcc-tag-pill.is-draft {
   background: #8a5d12;
+}
+
+.mcc-tag-pill.is-external {
+  background: #52616f;
 }
 
 .mcc-command-panel {
@@ -1909,8 +2019,9 @@ ol.mcc-guide-steps > li::before {
   line-height: 1.45;
 }
 
-.mcc-show-more-regions {
-  margin-top: 0.65rem;
+.mcc-selected-region .mcc-selected-shared-area {
+  color: var(--mcc-green-dark);
+  font-weight: 700;
 }
 
 .mcc-alternate-regions > summary,

--- a/docs/assets/regions/regions.js
+++ b/docs/assets/regions/regions.js
@@ -111,6 +111,68 @@
     data.metroGroups = (data.metroGroups || []).map(function (group) {
       return { label: group.label, tags: group.tags.filter(function (tag) { return Boolean(seedTags[tag]); }) };
     });
+    data.sharedRepeaterAreas = Object.keys(data.searchGroups || {}).map(function (id) {
+      var group = data.searchGroups[id];
+      if (!group || !group.repeaterConfig || group.repeaterConfig.mode !== "shared-member-paths") return null;
+      var members = unique((group.members || []).filter(function (tag) { return Boolean(seedTags[tag]); }));
+      if (members.length !== (group.members || []).length || members.length < 2) {
+        throw new Error("The Canadian region catalog contains an invalid shared repeater area: " + id);
+      }
+      members.sort(function (left, right) {
+        return ancestryText(data, left).localeCompare(ancestryText(data, right));
+      });
+      if (unique(members.map(function (tag) { return provinceTagFor(data, tag); })).length < 2) {
+        throw new Error("A shared repeater area must cross a province or territory: " + id);
+      }
+      return {
+        id: id,
+        label: group.label,
+        members: members,
+        defaultForMembers: group.repeaterConfig.defaultForMembers === true,
+        basis: group.repeaterConfig.basis || ""
+      };
+    }).filter(Boolean);
+    data.externalTagLabels = {};
+    data.externalTagParents = {};
+    data.externalRegionPathList = Object.keys(data.externalRegionPaths || {}).map(function (id) {
+      var record = data.externalRegionPaths[id];
+      var path = unique(((record && record.path) || []).map(slug).filter(Boolean));
+      if (!record || record.geographic !== false || record.automatic !== false || !path.length ||
+          path.length !== (record.path || []).length) {
+        throw new Error("The region catalog contains an invalid neighbouring network path: " + id);
+      }
+      path.forEach(function (tag, index) {
+        if (data.hierarchy[tag]) {
+          throw new Error("A neighbouring network tag collides with the Canadian hierarchy: " + tag);
+        }
+        var label = record.tagLabels && record.tagLabels[tag];
+        if (!label) {
+          throw new Error("A neighbouring network tag has no label: " + tag);
+        }
+        var parent = index ? path[index - 1] : null;
+        if (Object.prototype.hasOwnProperty.call(data.externalTagParents, tag) &&
+            data.externalTagParents[tag] !== parent) {
+          throw new Error("A neighbouring network tag has conflicting parents: " + tag);
+        }
+        if (data.externalTagLabels[tag] && data.externalTagLabels[tag] !== label) {
+          throw new Error("A neighbouring network tag has conflicting labels: " + tag);
+        }
+        data.externalTagParents[tag] = parent;
+        data.externalTagLabels[tag] = label;
+      });
+      return {
+        id: id,
+        label: record.label,
+        path: path,
+        status: record.authority && record.authority.status || "provisional",
+        source: record.authority && record.authority.source || "",
+        sourceUrl: record.authority && record.authority.sourceUrl || "",
+        eligibility: record.eligibility || "",
+        trafficEvidence: record.trafficEvidence || null
+      };
+    }).sort(function (left, right) {
+      return left.label.localeCompare(right.label);
+    });
     Object.defineProperty(data, "__mccPrepared", { value: true });
     return data;
   }
@@ -282,6 +344,7 @@
 
   function labelFor(data, tag) {
     if (data.hierarchy[tag]) return data.hierarchy[tag].label;
+    if (data.externalTagLabels && data.externalTagLabels[tag]) return data.externalTagLabels[tag];
     return tag;
   }
 
@@ -347,6 +410,42 @@
     return ancestryFor(data, tag).join(" -> ");
   }
 
+  function sharedRepeaterAreaForTag(data, tag) {
+    return (data.sharedRepeaterAreas || []).find(function (area) {
+      return area.members.indexOf(tag) !== -1;
+    }) || null;
+  }
+
+  function canonicalLeafOrder(data, tags) {
+    var seedTags = {};
+    (data.seeds || []).forEach(function (seed) { seedTags[seed.tag] = true; });
+    return unique(tags || []).filter(function (tag) {
+      return Boolean(seedTags[tag]);
+    }).sort(function (left, right) {
+      return ancestryText(data, left).localeCompare(ancestryText(data, right));
+    });
+  }
+
+  function selectedExternalRegionPaths(data, ids) {
+    var selected = {};
+    unique(ids || []).forEach(function (id) { selected[id] = true; });
+    return (data.externalRegionPathList || []).filter(function (record) {
+      return Boolean(selected[record.id]);
+    }).sort(function (left, right) {
+      return left.path.join("/").localeCompare(right.path.join("/"));
+    });
+  }
+
+  function defaultRepeaterLeaves(data, primaryTag) {
+    var area = sharedRepeaterAreaForTag(data, primaryTag);
+    if (area && area.defaultForMembers) return area.members.slice();
+    return [primaryTag];
+  }
+
+  function labelledPath(data, path) {
+    return path.map(function (tag) { return labelFor(data, tag); }).join(" › ");
+  }
+
   function seedText(seed) {
     return seed
       ? seed.lat.toFixed(4) + ", " + seed.lon.toFixed(4) + " / r " + (seed.r || 0) + " km"
@@ -382,6 +481,13 @@
     if (state.name) params.set("name", state.name);
     if (state.resolution && state.resolution.primary) {
       params.set("tag", state.forcedTag || state.resolution.primary.seed.tag);
+    }
+    if (state.type === "high-site") params.set("type", "large");
+    if (state.selectedMetros && state.selectedMetros.length) {
+      params.set("regions", state.selectedMetros.join(","));
+    }
+    if (state.selectedExternalPaths && state.selectedExternalPaths.length) {
+      params.set("external", state.selectedExternalPaths.join(","));
     }
     return regionPageHref("map") + (params.toString() ? "?" + params.toString() : "");
   }
@@ -490,12 +596,16 @@
     };
   }
 
-  function recommend(data, resolution, type, selectedMetros) {
+  function recommend(data, resolution, type, selectedMetros, selectedExternalPaths) {
     if (!resolution || !resolution.primary) return null;
     var primaryTag = resolution.primary.seed.tag;
     var carryTags = type === "high-site" && selectedMetros && selectedMetros.length
       ? selectedMetros
-      : [primaryTag];
+      : defaultRepeaterLeaves(data, primaryTag);
+    carryTags = canonicalLeafOrder(data, carryTags);
+    var externalPaths = type === "high-site"
+      ? selectedExternalRegionPaths(data, selectedExternalPaths)
+      : [];
     var tags = [];
     var parentOverrides = {};
     var notes = [];
@@ -503,13 +613,28 @@
     carryTags.forEach(function (tag) {
       tags = tags.concat(ancestryFor(data, tag));
     });
+    externalPaths.forEach(function (record) {
+      tags = tags.concat(record.path);
+      record.path.forEach(function (tag) {
+        parentOverrides[tag] = data.externalTagParents[tag];
+      });
+      if (record.status !== "documented") {
+        notes.push("Confirm " + record.label + " tags with neighbouring operators before applying them.");
+      }
+    });
     tags = unique(tags);
+    var paths = carryTags.map(function (tag) { return ancestryFor(data, tag); })
+      .concat(externalPaths.map(function (record) { return record.path; }));
+    var jurisdictions = unique(carryTags.map(function (tag) { return provinceTagFor(data, tag); }));
+    var sharedArea = sharedRepeaterAreaForTag(data, primaryTag);
 
     var reviewTags = tags.filter(function (tag) {
+      if (data.externalTagLabels && data.externalTagLabels[tag]) return false;
       var state = statusFor(data, tag).state;
       return state === "draft";
     });
     var deprecatedTags = tags.filter(function (tag) {
+      if (data.externalTagLabels && data.externalTagLabels[tag]) return false;
       return statusFor(data, tag).state === "deprecated";
     });
     if (reviewTags.length) {
@@ -529,6 +654,11 @@
 
     return {
       tags: tags,
+      leaves: carryTags,
+      paths: paths,
+      jurisdictions: jurisdictions,
+      sharedArea: sharedArea,
+      externalPaths: externalPaths,
       parentOverrides: parentOverrides,
       budget: budget,
       notes: notes
@@ -549,7 +679,10 @@
   }
 
   function effectiveParentFor(data, tag, parentOverrides) {
-    return parentOverrides && parentOverrides[tag] || parentFor(data, tag);
+    if (parentOverrides && Object.prototype.hasOwnProperty.call(parentOverrides, tag)) {
+      return parentOverrides[tag];
+    }
+    return parentFor(data, tag);
   }
 
   function regionDefTokens(data, tags, parentOverrides) {
@@ -844,50 +977,99 @@
       return;
     }
     var primaryTag = state.resolution.primary.seed.tag;
-    var provinceTag = provinceTagFor(data, primaryTag);
-    var provinceGroup = data.metroGroups.find(function (group) {
-      return group.tags.indexOf(primaryTag) !== -1;
-    });
-    var allTags = provinceGroup
-      ? provinceGroup.tags.filter(function (tag) { return provinceTagFor(data, tag) === provinceTag; })
-      : data.seeds.filter(function (seed) { return provinceTagFor(data, seed.tag) === provinceTag; }).map(function (seed) { return seed.tag; });
-    var nearbyTags = unique(state.resolution.top5.map(function (entry) { return entry.seed.tag; }))
-      .filter(function (tag) { return allTags.indexOf(tag) !== -1; });
-    var preselect = {};
     if (!state.selectedMetros.length) {
-      nearbyTags.slice(0, 2).forEach(function (tag) {
-        preselect[tag] = true;
-      });
-      state.selectedMetros = Object.keys(preselect);
+      state.selectedMetros = defaultRepeaterLeaves(data, primaryTag);
     }
-    var visibleTags = state.showAllMetros
-      ? allTags
-      : unique(nearbyTags.concat(state.selectedMetros));
-    var hiddenCount = Math.max(0, allTags.length - visibleTags.length);
+    state.selectedExternalPaths = state.selectedExternalPaths || [];
+    var sharedArea = sharedRepeaterAreaForTag(data, primaryTag);
+    var requiredTags = unique([primaryTag].concat(sharedArea && sharedArea.defaultForMembers ? sharedArea.members : []));
+    state.selectedMetros = canonicalLeafOrder(data, state.selectedMetros.concat(requiredTags));
+    var nearbyTags = rankSeeds(data, state.lat, state.lon, null).slice(0, 6).map(function (entry) {
+      return entry.seed.tag;
+    });
+    var visibleTags = canonicalLeafOrder(data, state.selectedMetros.concat(nearbyTags));
+    var groups = (data.metroGroups || []).map(function (group) {
+      return {
+        label: group.label,
+        tags: group.tags.filter(function (tag) { return visibleTags.indexOf(tag) !== -1; })
+      };
+    }).filter(function (group) { return group.tags.length; });
+    var allGroups = (data.metroGroups || []).map(function (group) {
+      return {
+        label: group.label,
+        tags: group.tags.filter(function (tag) { return visibleTags.indexOf(tag) === -1; })
+      };
+    }).filter(function (group) { return group.tags.length; });
+    var sharedNote = sharedArea
+      ? '<div class="mcc-shared-area-note"><strong>Shared repeater area</strong><span>' +
+        esc(sharedArea.label) + " keeps " + esc(sharedArea.members.map(function (tag) {
+          return labelFor(data, tag);
+        }).join(" and ")) + " in one repeater configuration.</span></div>"
+      : "";
+    var externalChoices = (data.externalRegionPathList || []).map(function (record) {
+      var checked = state.selectedExternalPaths.indexOf(record.id) !== -1 ? " checked" : "";
+      var status = record.status === "documented" ? "community path" : "confirm locally";
+      return '<label class="mcc-neighbour-path"><input type="checkbox" data-external-path value="' +
+        esc(record.id) + '"' + checked + '><span><strong>' + esc(record.label) + '</strong><small><code>' +
+        esc(record.path.join(" › ")) + "</code> · " + esc(status) + "</small></span></label>";
+    }).join("");
 
-    target.innerHTML = '<p class="mcc-hint">Select each region this high site will serve.</p>' +
-      '<div class="mcc-chip-group"><strong>' + esc(provinceGroup ? provinceGroup.label : labelFor(data, provinceTag)) + '</strong><div class="mcc-chip-list">' +
-          visibleTags.map(function (tag) {
+    target.innerHTML = '<p class="mcc-hint">Add only the paths this repeater should forward. Different repeaters can carry different paths to spread traffic.</p>' +
+      sharedNote +
+      '<h3 class="mcc-picker-heading">Canadian regions</h3>' +
+      '<p class="mcc-hint">Provinces and territories may be mixed.</p>' +
+      '<div class="mcc-served-region-groups">' +
+      groups.map(function (group) {
+        return '<div class="mcc-chip-group"><strong>' + esc(group.label) + '</strong><div class="mcc-chip-list">' +
+          group.tags.map(function (tag) {
             var checked = state.selectedMetros.indexOf(tag) !== -1 ? " checked" : "";
-            return '<label class="mcc-chip"><input type="checkbox" value="' + esc(tag) + '"' + checked + '> <code>' + esc(tag) + "</code> " + esc(labelFor(data, tag)) + "</label>";
+            var required = requiredTags.indexOf(tag) !== -1;
+            return '<label class="mcc-chip' + (required ? " is-required" : "") + '"><input type="checkbox" data-canadian-region value="' +
+              esc(tag) + '"' + checked + (required ? " disabled" : "") + '> <code>' + esc(tag) + "</code> " +
+              esc(labelFor(data, tag)) + (required ? '<span class="mcc-chip-required">required</span>' : "") + "</label>";
           }).join("") +
-          "</div>" +
-          (hiddenCount ? '<button type="button" class="mcc-button mcc-button-secondary mcc-show-more-regions" data-action="show-all-regions">Add another region (' + hiddenCount + ' more)</button>' : '') +
-          "</div>";
+          "</div></div>";
+      }).join("") +
+      '</div>' +
+      '<label class="mcc-label mcc-add-region-label">Add any Canadian region</label>' +
+      '<select class="mcc-select" data-action="add-served-region">' +
+      '<option value="">Choose a region</option>' +
+      allGroups.map(function (group) {
+        return '<optgroup label="' + esc(group.label) + '">' + group.tags.map(function (tag) {
+          return '<option value="' + esc(tag) + '">' + esc(labelFor(data, tag)) + " (" + esc(tag) + ")</option>";
+        }).join("") + "</optgroup>";
+      }).join("") +
+      "</select>" +
+      (externalChoices
+        ? '<div class="mcc-neighbour-paths"><h3 class="mcc-picker-heading">Neighbouring network paths</h3>' +
+          '<p class="mcc-hint">These paths were seen in Canada–U.S. routes. Nothing outside Canada is added to the boundary map.</p>' +
+          '<div class="mcc-neighbour-path-list">' + externalChoices + "</div></div>"
+        : "");
 
-    target.querySelectorAll("input[type='checkbox']").forEach(function (input) {
+    target.querySelectorAll("input[data-canadian-region]").forEach(function (input) {
       input.addEventListener("change", function () {
-        state.selectedMetros = Array.prototype.slice.call(target.querySelectorAll("input[type='checkbox']:checked")).map(function (item) {
+        state.selectedMetros = Array.prototype.slice.call(target.querySelectorAll("input[data-canadian-region]:checked")).map(function (item) {
+          return item.value;
+        });
+        state.selectedMetros = canonicalLeafOrder(data, state.selectedMetros);
+        onChange();
+      });
+    });
+    target.querySelectorAll("input[data-external-path]").forEach(function (input) {
+      input.addEventListener("change", function () {
+        state.selectedExternalPaths = Array.prototype.slice.call(target.querySelectorAll("input[data-external-path]:checked")).map(function (item) {
           return item.value;
         });
         onChange();
       });
     });
-    var showAll = target.querySelector("[data-action='show-all-regions']");
-    if (showAll) {
-      showAll.addEventListener("click", function () {
-        state.showAllMetros = true;
+    var addRegion = target.querySelector("[data-action='add-served-region']");
+    if (addRegion) {
+      addRegion.addEventListener("change", function () {
+        if (!addRegion.value) return;
+        state.selectedMetros = canonicalLeafOrder(data, state.selectedMetros.concat(addRegion.value));
         renderMetroChips(data, target, state, onChange);
+        onChange();
       });
     }
   }
@@ -904,7 +1086,7 @@
       return;
     }
 
-    var rec = recommend(data, state.resolution, state.type, state.selectedMetros);
+    var rec = recommend(data, state.resolution, state.type, state.selectedMetros, state.selectedExternalPaths);
     if (!rec) {
       target.innerHTML = '<div class="mcc-empty-state">' + icon("radio-tower") + '<strong>No region yet</strong></div>';
       refreshIcons(target);
@@ -925,14 +1107,36 @@
     var titleTag = state.resolution.primary.seed.tag;
     var statusNotes = rec.notes.map(function (note) {
       var warning = note.indexOf("Check locally") === 0 || note.indexOf("Do not use") === 0 ||
-        note.indexOf("Approximate") === 0 || note.indexOf("Too many") === 0 || note.indexOf("Region names use") === 0;
+        note.indexOf("Approximate") === 0 || note.indexOf("Confirm ") === 0 ||
+        note.indexOf("Too many") === 0 || note.indexOf("Region names use") === 0;
       return '<div class="mcc-note' + (warning ? " mcc-note-warning" : "") + '">' + esc(note) + "</div>";
     }).join("");
     var firmwareLabel = firmware === "1.16" ? "v1.16+" : firmware === "1.15" ? "v1.15.x" : "v1.14.x";
     var guided = state.finishPath === "guided";
     var verificationCommands = ["region"];
     if (state.includeBaseline) verificationCommands.push("get radio");
-    var expectedPath = rec.tags.map(function (tag) { return labelFor(data, tag); }).join(" › ");
+    var expectedPaths = rec.paths.map(function (path) { return labelledPath(data, path); });
+    var expectedPathMarkup = '<div class="mcc-region-path-list">' + expectedPaths.map(function (path) {
+      return "<span>" + esc(path) + "</span>";
+    }).join("") + "</div>";
+    var multiProvince = rec.jurisdictions.length > 1;
+    var scopeNotices = [];
+    if (rec.sharedArea) {
+      scopeNotices.push('<div class="mcc-shared-area-note"><strong>Shared repeater area</strong><span>' +
+        esc(rec.sharedArea.label) + " combines " + esc(rec.sharedArea.members.map(function (tag) {
+          return labelFor(data, tag);
+        }).join(" and ")) + " in one repeater setup. All map boundaries remain separate.</span></div>");
+    } else if (multiProvince) {
+      scopeNotices.push('<div class="mcc-shared-area-note"><strong>Cross-province repeater setup</strong><span>' +
+        esc(rec.jurisdictions.map(function (tag) { return labelFor(data, tag); }).join(" + ")) +
+        ". Each map region keeps its own boundary.</span></div>");
+    }
+    if (rec.externalPaths.length) {
+      scopeNotices.push('<div class="mcc-shared-area-note"><strong>Neighbouring network paths</strong><span>' +
+        esc(rec.externalPaths.map(function (record) { return record.label; }).join(" + ")) +
+        " is added to this repeater only. MeshCore Canada does not own or draw those boundaries.</span></div>");
+    }
+    var scopeNotice = scopeNotices.join("");
     var resultBody = guided
       ? '<div class="mcc-guide-panel">' +
         '<ol class="mcc-guide-steps">' +
@@ -954,8 +1158,8 @@
         '<div class="mcc-guide-command-list">' + commands.map(function (line) {
           return '<button type="button" class="mcc-command-line" data-cmd="' + esc(line) + '"><span>' + esc(line) + '</span><em>' + icon("copy") + 'Copy</em></button>';
         }).join("") + '</div><p class="mcc-guide-stop">Stop on <code>Err</code>. Existing regions are not cleared.</p></div></li>' +
-        '<li><div><h4>Check and save</h4><p>Run <code>region</code> and confirm:</p>' +
-        '<p class="mcc-region-path"><strong>' + esc(expectedPath) + '</strong></p>' +
+        '<li><div><h4>Check and save</h4><p>Run <code>region</code> and confirm each path:</p>' +
+        expectedPathMarkup +
         '<div class="mcc-guide-command-list"><button type="button" class="mcc-command-line" data-cmd="region"><span>region</span><em>' + icon("copy") + 'Copy</em></button></div>' +
         '<p>Save:</p>' +
         '<div class="mcc-guide-command-list"><button type="button" class="mcc-command-line" data-cmd="region save"><span>region save</span><em>' + icon("copy") + 'Copy</em></button></div>' +
@@ -981,8 +1185,10 @@
       (state.resolution.sourceTier === "generated" ? "Canada-wide region boundary" : "Boundary unavailable") + '</span>';
     var ancestryMarkup = '<div class="mcc-ancestry" aria-label="Region tags">' +
       rec.tags.map(function (tag) {
-        var stateName = statusFor(data, tag).state || "draft";
-        return '<span class="mcc-tag-pill' + (stateName === "draft" ? " is-draft" : "") + '"><code>' + esc(tag) + "</code></span>";
+        var external = Boolean(data.externalTagLabels && data.externalTagLabels[tag]);
+        var stateName = external ? "external" : statusFor(data, tag).state || "draft";
+        return '<span class="mcc-tag-pill' + (stateName === "draft" ? " is-draft" : "") +
+          (external ? " is-external" : "") + '"><code>' + esc(tag) + "</code></span>";
       }).join("") +
       "</div>";
     var metaMarkup = '<dl class="mcc-result-meta">' +
@@ -1000,10 +1206,12 @@
       '<div>' +
       '<h3 class="mcc-result-title"><code>' + esc(titleTag.toUpperCase()) + "</code> — " + esc(labelFor(data, titleTag)) + "</h3>" +
       '<div class="mcc-result-sub">' + esc(state.name || labelFor(data, titleTag)) + "</div>" +
-      '<div class="mcc-region-path"><strong>Your region:</strong> ' + esc(expectedPath) + '</div>' +
+      '<div class="mcc-region-path"><strong>' + (rec.paths.length > 1 ? "Repeater regions:" : "Your region:") + "</strong>" +
+      expectedPathMarkup + "</div>" +
       '</div>' +
       (!guided ? '<button type="button" class="mcc-button mcc-copy-all">' + icon("copy") + 'Copy commands</button>' : '') +
       '</div>' +
+      scopeNotice +
       technicalDetails +
       resultBody +
       (statusNotes ? '<div class="mcc-notes">' + statusNotes + "</div>" : "") +
@@ -1042,7 +1250,7 @@
 
   function currentCommands(data, state) {
     if (!state || !state.canGenerate || !state.resolution) return null;
-    var rec = recommend(data, state.resolution, state.type, state.selectedMetros);
+    var rec = recommend(data, state.resolution, state.type, state.selectedMetros, state.selectedExternalPaths);
     if (!rec) return null;
     if (rec.budget.tagCount > 32 || rec.budget.responseBytes > 172) return null;
     var firmware = state.firmware || data.meta.defaultFirmware || "1.16";
@@ -1061,6 +1269,7 @@
     var seed = seedForTag(data, tag);
     var sourceUrl = sourceUrlFor(data, tag);
     var ancestry = ancestryFor(data, tag);
+    var sharedArea = sharedRepeaterAreaForTag(data, tag);
     var commands = state && state.canGenerate && state.resolution &&
       state.resolution.primary && state.resolution.primary.seed.tag === tag
       ? currentCommands(data, state)
@@ -1088,6 +1297,10 @@
       '<div><dt>Seed</dt><dd>' + (seed
         ? esc(seed.lat.toFixed(4) + ", " + seed.lon.toFixed(4) + " / r " + (seed.r || 0) + " km")
         : "No seed point") + '</dd></div>' +
+      (sharedArea
+        ? '<div><dt>Repeater area</dt><dd>' + esc(sharedArea.label) + " · " +
+          esc(sharedArea.members.map(function (member) { return labelFor(data, member); }).join(" + ")) + "</dd></div>"
+        : "") +
       '<div><dt>Source note</dt><dd>' + (pnwAligned ? "BC coastal seed follows the PNW reference data" : "Strategy draft v1.1.1 region") + '</dd></div>' +
       '</dl>' +
       '<div class="mcc-detail-actions">' +
@@ -1132,11 +1345,13 @@
     renderCandidateList(data, els.candidates, state, function (tag) {
       state.forcedTag = tag;
       state.selectedMetros = [];
-      state.showAllMetros = false;
+      state.selectedExternalPaths = [];
       refreshTool(data, els, state, afterRefresh);
     });
     renderMetroChips(data, els.metro, state, function () {
       renderResult(data, els.result, state);
+      renderRegionDetail(data, els.detailSection, els.detail, state, state.detailTag);
+      if (afterRefresh) afterRefresh();
     });
     renderResult(data, els.result, state);
     renderRegionDetail(data, els.detailSection, els.detail, state, state.detailTag);
@@ -1196,7 +1411,7 @@
       '<div class="mcc-choice-list" data-role="types" role="group" aria-label="Repeater installation type">' +
       '<label class="mcc-choice"><input type="radio" name="mcc-type" value="residential" checked><span><strong>Home or portable</strong></span></label>' +
       '<label class="mcc-choice"><input type="radio" name="mcc-type" value="urban"><span><strong>Rooftop or tower</strong></span></label>' +
-      '<label class="mcc-choice"><input type="radio" name="mcc-type" value="high-site"><span><strong>Mountaintop / wide coverage</strong></span></label>' +
+      '<label class="mcc-choice"><input type="radio" name="mcc-type" value="high-site"><span><strong>Large or cross-border coverage</strong><small>Choose forwarding paths</small></span></label>' +
       '</div>' +
       '<div data-role="metro"></div>' +
       '<div class="mcc-wizard-actions"><button class="mcc-button mcc-button-secondary" type="button" data-prev-step>' + icon("arrow-left") + 'Back</button><button class="mcc-button" type="button" data-next-step>Next' + icon("arrow-right") + '</button></div>' +
@@ -1227,7 +1442,7 @@
       firmware: data.meta.defaultFirmware || "1.16",
       includeBaseline: true,
       selectedMetros: [],
-      showAllMetros: false,
+      selectedExternalPaths: [],
       canGenerate: false,
       resolution: null,
       browseTag: data.meta.rootTag || "can",
@@ -1318,12 +1533,14 @@
       var selectedTag = state.resolution && state.resolution.primary
         ? state.resolution.primary.seed.tag
         : null;
+      var sharedArea = selectedTag ? sharedRepeaterAreaForTag(data, selectedTag) : null;
       if (els.selectedRegion) {
         els.selectedRegion.hidden = !selectedTag;
         els.selectedRegion.innerHTML = selectedTag
-          ? '<strong>Your region</strong><span>' + esc(ancestryFor(data, selectedTag).map(function (item) {
+          ? '<strong>Your home region</strong><span>' + esc(ancestryFor(data, selectedTag).map(function (item) {
             return labelFor(data, item);
-          }).join(" › ")) + '</span>'
+          }).join(" › ")) + '</span>' +
+            (sharedArea ? '<span class="mcc-selected-shared-area">Shared repeater area: ' + esc(sharedArea.label) + "</span>" : "")
           : "";
       }
       if (els.regionBrowser) els.regionBrowser.hidden = !selectedTag;
@@ -1368,7 +1585,7 @@
         ? provinceTagFor(data, state.forcedTag)
         : jurisdictionTagFromGeo(geo);
       state.selectedMetros = [];
-      state.showAllMetros = false;
+      state.selectedExternalPaths = [];
       if (!isCanada(geo)) {
         state.canGenerate = false;
         state.resolution = null;
@@ -1458,8 +1675,9 @@
       input.addEventListener("change", function () {
         state.type = input.value;
         state.selectedMetros = [];
-        state.showAllMetros = false;
-        refreshTool(data, els, state);
+        state.selectedExternalPaths = [];
+        refreshTool(data, els, state, updateMapLinks);
+        updateMapLinks();
       });
     });
     el.querySelectorAll("input[name='mcc-firmware']").forEach(function (input) {
@@ -1525,7 +1743,7 @@
       '<div class="mcc-choice-list" role="group" aria-label="Repeater installation type">' +
       '<label class="mcc-choice"><input type="radio" name="mcc-map-type" value="residential" checked><span><strong>Home or portable</strong></span></label>' +
       '<label class="mcc-choice"><input type="radio" name="mcc-map-type" value="urban"><span><strong>Rooftop or tower</strong></span></label>' +
-      '<label class="mcc-choice"><input type="radio" name="mcc-map-type" value="high-site"><span><strong>Mountaintop / wide coverage</strong></span></label>' +
+      '<label class="mcc-choice"><input type="radio" name="mcc-map-type" value="high-site"><span><strong>Large or cross-border coverage</strong><small>Choose forwarding paths</small></span></label>' +
       '</div>' +
       '<div data-role="map-metro"></div>' +
       '<label class="mcc-label" for="mcc-map-firmware">Firmware</label>' +
@@ -1539,17 +1757,27 @@
       '</div>';
     refreshIcons(el);
 
+    var mapParams = new URLSearchParams(window.location.search);
+    var requestedLargeCoverage = mapParams.get("type") === "large";
+    var requestedCanadianRegions = canonicalLeafOrder(
+      data,
+      String(mapParams.get("regions") || "").split(",").map(slug).filter(Boolean)
+    );
+    var requestedExternalPaths = selectedExternalRegionPaths(
+      data,
+      String(mapParams.get("external") || "").split(",").map(slug).filter(Boolean)
+    ).map(function (record) { return record.id; });
     var state = {
       lat: null,
       lon: null,
       name: "",
       forcedTag: null,
       jurisdictionTag: null,
-      type: "residential",
+      type: requestedLargeCoverage ? "high-site" : "residential",
       firmware: data.meta.defaultFirmware || "1.16",
       includeBaseline: true,
       selectedMetros: [],
-      showAllMetros: false,
+      selectedExternalPaths: [],
       canGenerate: false,
       resolution: null,
       detailTag: null,
@@ -1572,6 +1800,8 @@
     };
     var afterMapRefresh = function () {};
     el.querySelector("[data-role='map-firmware']").value = state.firmware;
+    var initialTypeInput = el.querySelector("input[name='mcc-map-type'][value='" + state.type + "']");
+    if (initialTypeInput) initialTypeInput.checked = true;
 
     loadLeaflet().then(function (L) {
       if (!el.isConnected) return;
@@ -1621,8 +1851,12 @@
 
       function updateBoundaryHighlight() {
         selectedLayer.clearLayers();
-        if (state.resolution && state.resolution.displayBoundary) {
-          selectedLayer.addData(state.resolution.displayBoundary);
+        var rec = recommend(data, state.resolution, state.type, state.selectedMetros, state.selectedExternalPaths);
+        if (rec) {
+          selectedLayer.addData({
+            type: "FeatureCollection",
+            features: rec.leaves.map(function (tag) { return data.partitionByTag[tag]; }).filter(Boolean)
+          });
           selectedLayer.bringToFront();
         }
       }
@@ -1700,7 +1934,7 @@
           ? provinceTagFor(data, state.forcedTag)
           : jurisdictionTagFromGeo(geo);
         state.selectedMetros = [];
-        state.showAllMetros = false;
+        state.selectedExternalPaths = [];
         place(state.lat, state.lon);
         if (!isCanada(geo)) {
           state.forcedTag = null;
@@ -1737,7 +1971,7 @@
         state.forcedTag = null;
         state.jurisdictionTag = null;
         state.selectedMetros = [];
-        state.showAllMetros = false;
+        state.selectedExternalPaths = [];
         state.canGenerate = false;
         state.resolution = null;
         state.detailTag = null;
@@ -1791,16 +2025,24 @@
         verifyAndUseGeo(lat, lon, lat.toFixed(4) + ", " + lon.toFixed(4), false);
       });
 
-      var params = new URLSearchParams(window.location.search);
-      var initialLatRaw = params.get("lat");
-      var initialLonRaw = params.get("lon");
+      var initialLatRaw = mapParams.get("lat");
+      var initialLonRaw = mapParams.get("lon");
       var initialLat = initialLatRaw === null || initialLatRaw.trim() === "" ? NaN : Number(initialLatRaw);
       var initialLon = initialLonRaw === null || initialLonRaw.trim() === "" ? NaN : Number(initialLonRaw);
       var hasInitialLocation = Number.isFinite(initialLat) && Number.isFinite(initialLon);
       if (hasInitialLocation) {
-        var initialName = params.get("name") || (initialLat.toFixed(4) + ", " + initialLon.toFixed(4));
+        var initialName = mapParams.get("name") || (initialLat.toFixed(4) + ", " + initialLon.toFixed(4));
         els.input.value = initialName;
-        verifyAndUseGeo(initialLat, initialLon, initialName, true, params.get("tag"));
+        verifyAndUseGeo(initialLat, initialLon, initialName, true, mapParams.get("tag")).then(function () {
+          if (!requestedLargeCoverage || !state.canGenerate) return;
+          state.type = "high-site";
+          state.selectedMetros = requestedCanadianRegions;
+          state.selectedExternalPaths = requestedExternalPaths;
+          refreshTool(data, els, state, updateBoundaryHighlight);
+          if (selectedLayer.getBounds().isValid()) {
+            map.fitBounds(selectedLayer.getBounds(), { padding: [28, 28], maxZoom: 8 });
+          }
+        });
       } else {
         fitCanada();
       }
@@ -1816,7 +2058,7 @@
       input.addEventListener("change", function () {
         state.type = input.value;
         state.selectedMetros = [];
-        state.showAllMetros = false;
+        state.selectedExternalPaths = [];
         refreshTool(data, els, state, afterMapRefresh);
       });
     });

--- a/docs/assets/regions/regions.js
+++ b/docs/assets/regions/regions.js
@@ -426,6 +426,17 @@
     });
   }
 
+  function expandSharedRepeaterLeaves(data, tags) {
+    var expanded = canonicalLeafOrder(data, tags);
+    expanded.slice().forEach(function (tag) {
+      var area = sharedRepeaterAreaForTag(data, tag);
+      if (area && area.defaultForMembers) {
+        expanded = expanded.concat(area.members);
+      }
+    });
+    return canonicalLeafOrder(data, expanded);
+  }
+
   function selectedExternalRegionPaths(data, ids) {
     var selected = {};
     unique(ids || []).forEach(function (id) { selected[id] = true; });
@@ -437,9 +448,7 @@
   }
 
   function defaultRepeaterLeaves(data, primaryTag) {
-    var area = sharedRepeaterAreaForTag(data, primaryTag);
-    if (area && area.defaultForMembers) return area.members.slice();
-    return [primaryTag];
+    return expandSharedRepeaterLeaves(data, [primaryTag]);
   }
 
   function labelledPath(data, path) {
@@ -602,7 +611,7 @@
     var carryTags = type === "high-site" && selectedMetros && selectedMetros.length
       ? selectedMetros
       : defaultRepeaterLeaves(data, primaryTag);
-    carryTags = canonicalLeafOrder(data, carryTags);
+    carryTags = expandSharedRepeaterLeaves(data, carryTags);
     var externalPaths = type === "high-site"
       ? selectedExternalRegionPaths(data, selectedExternalPaths)
       : [];
@@ -982,8 +991,8 @@
     }
     state.selectedExternalPaths = state.selectedExternalPaths || [];
     var sharedArea = sharedRepeaterAreaForTag(data, primaryTag);
-    var requiredTags = unique([primaryTag].concat(sharedArea && sharedArea.defaultForMembers ? sharedArea.members : []));
-    state.selectedMetros = canonicalLeafOrder(data, state.selectedMetros.concat(requiredTags));
+    var requiredTags = defaultRepeaterLeaves(data, primaryTag);
+    state.selectedMetros = expandSharedRepeaterLeaves(data, state.selectedMetros.concat(requiredTags));
     var nearbyTags = rankSeeds(data, state.lat, state.lon, null).slice(0, 6).map(function (entry) {
       return entry.seed.tag;
     });
@@ -1048,10 +1057,17 @@
 
     target.querySelectorAll("input[data-canadian-region]").forEach(function (input) {
       input.addEventListener("change", function () {
-        state.selectedMetros = Array.prototype.slice.call(target.querySelectorAll("input[data-canadian-region]:checked")).map(function (item) {
+        var selected = Array.prototype.slice.call(target.querySelectorAll("input[data-canadian-region]:checked")).map(function (item) {
           return item.value;
         });
-        state.selectedMetros = canonicalLeafOrder(data, state.selectedMetros);
+        var changedArea = sharedRepeaterAreaForTag(data, input.value);
+        if (changedArea && changedArea.defaultForMembers) {
+          selected = input.checked
+            ? selected.concat(changedArea.members)
+            : selected.filter(function (tag) { return changedArea.members.indexOf(tag) === -1; });
+        }
+        state.selectedMetros = expandSharedRepeaterLeaves(data, selected.concat(requiredTags));
+        renderMetroChips(data, target, state, onChange);
         onChange();
       });
     });
@@ -1067,7 +1083,7 @@
     if (addRegion) {
       addRegion.addEventListener("change", function () {
         if (!addRegion.value) return;
-        state.selectedMetros = canonicalLeafOrder(data, state.selectedMetros.concat(addRegion.value));
+        state.selectedMetros = expandSharedRepeaterLeaves(data, state.selectedMetros.concat(addRegion.value));
         renderMetroChips(data, target, state, onChange);
         onChange();
       });
@@ -1759,7 +1775,7 @@
 
     var mapParams = new URLSearchParams(window.location.search);
     var requestedLargeCoverage = mapParams.get("type") === "large";
-    var requestedCanadianRegions = canonicalLeafOrder(
+    var requestedCanadianRegions = expandSharedRepeaterLeaves(
       data,
       String(mapParams.get("regions") || "").split(",").map(slug).filter(Boolean)
     );

--- a/docs/assets/regions/regions.js
+++ b/docs/assets/regions/regions.js
@@ -1051,7 +1051,7 @@
       "</select>" +
       (externalChoices
         ? '<div class="mcc-neighbour-paths"><h3 class="mcc-picker-heading">Neighbouring network paths</h3>' +
-          '<p class="mcc-hint">These paths were seen in Canada–U.S. routes. Nothing outside Canada is added to the boundary map.</p>' +
+          '<p class="mcc-hint">Add one only when this repeater should forward traffic for that area. Nothing outside Canada is added to the boundary map.</p>' +
           '<div class="mcc-neighbour-path-list">' + externalChoices + "</div></div>"
         : "");
 

--- a/docs/config/editor/app.js
+++ b/docs/config/editor/app.js
@@ -102,6 +102,7 @@ import {
   var elements = {
     province: document.getElementById("province-select"),
     target: document.getElementById("target-select"),
+    sharedAreaNote: document.getElementById("shared-area-note"),
     loadStatus: document.getElementById("load-status"),
     mapHeading: document.getElementById("map-heading"),
     panMode: document.getElementById("pan-mode"),
@@ -220,6 +221,46 @@ import {
     return entry && entry.label ? entry.label : tag;
   }
 
+  function sharedRepeaterAreaForTag(tag) {
+    var groups = state.catalog && state.catalog.searchGroups || {};
+    var id = Object.keys(groups).find(function (candidate) {
+      var group = groups[candidate];
+      return group && group.repeaterConfig &&
+        group.repeaterConfig.mode === "shared-member-paths" &&
+        Array.isArray(group.members) &&
+        group.members.indexOf(tag) !== -1;
+    });
+    if (!id) return null;
+    return Object.assign({ id: id }, groups[id]);
+  }
+
+  function provinceLabelForLeaf(tag) {
+    var provinces = leafProvinces.get(tag);
+    if (!provinces || !provinces.size) return "";
+    return Array.from(provinces).map(function (pruid) {
+      return provinceNames[pruid] || pruid;
+    }).join(" / ");
+  }
+
+  function updateSharedAreaNote() {
+    if (!elements.sharedAreaNote) return;
+    var selectedTag = state.selectedId ? effectiveLeaf(state.selectedId) : "";
+    var areas = [selectedTag, state.target].filter(Boolean).map(sharedRepeaterAreaForTag).filter(Boolean);
+    var area = areas[0] || null;
+    var heading = elements.sharedAreaNote.querySelector("strong");
+    var text = elements.sharedAreaNote.querySelector("span");
+    if (!area) {
+      heading.textContent = "Repeater paths";
+      text.textContent = "This editor changes Canadian map cells only. Choose cross-province and U.S. paths in the configurator.";
+      return;
+    }
+    heading.textContent = area.label;
+    text.textContent = area.members.map(function (tag) {
+      var province = provinceLabelForLeaf(tag);
+      return (province ? province + ": " : "") + leafLabel(tag);
+    }).join(" + ") + ". Edit each province separately; repeater setup keeps the paths together.";
+  }
+
   function colourForTag(tag) {
     var hash = 0;
     for (var index = 0; index < tag.length; index += 1) {
@@ -333,6 +374,7 @@ import {
     rows[2].textContent = leafLabel(effectiveLeaf(dguid)) + " (" + effectiveLeaf(dguid) + ")";
     rows[3].textContent = properties.seed_tag ? leafLabel(properties.seed_tag) + " (fixed)" : "No";
     elements.municipality.disabled = !properties.CSDUID || !state.target;
+    updateSharedAreaNote();
   }
 
   function setEffective(dguid, leaf) {
@@ -672,6 +714,7 @@ import {
     rows[2].textContent = "—";
     rows[3].textContent = "—";
     elements.municipality.disabled = true;
+    updateSharedAreaNote();
   }
 
   async function loadProvince(pruid) {
@@ -985,6 +1028,7 @@ import {
   elements.target.addEventListener("change", function () {
     state.target = elements.target.value;
     elements.municipality.disabled = !state.selectedId || !state.target;
+    updateSharedAreaNote();
   });
   elements.panMode.addEventListener("click", function () { setMode("pan"); });
   elements.paintMode.addEventListener("click", function () { setMode("paint"); });

--- a/docs/config/editor/editor.css
+++ b/docs/config/editor/editor.css
@@ -340,6 +340,31 @@ textarea {
   color: var(--success);
 }
 
+.shared-area-note {
+  display: grid;
+  gap: 0.18rem;
+  margin-top: 0.75rem;
+  padding: 0.7rem;
+  border: 1px solid rgba(133, 139, 255, 0.42);
+  border-radius: 8px;
+  background: var(--accent-soft);
+}
+
+.shared-area-note strong {
+  font-size: 0.8rem;
+}
+
+.shared-area-note span,
+.shared-area-note a {
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+
+.shared-area-note a {
+  color: #bec1ff;
+  font-weight: 750;
+}
+
 .segmented {
   background: #151720;
   border: 1px solid var(--border);

--- a/docs/config/editor/index.html
+++ b/docs/config/editor/index.html
@@ -45,6 +45,11 @@
         <select id="target-select" disabled>
           <option value="">Choose a target region</option>
         </select>
+        <div id="shared-area-note" class="shared-area-note">
+          <strong>Repeater paths</strong>
+          <span>This editor changes Canadian map cells only. Choose cross-province and U.S. paths in the configurator.</span>
+          <a href="../standard/#cross-province-repeater-areas">Read the rule</a>
+        </div>
         <div class="segmented" aria-label="Editing mode">
           <button id="pan-mode" class="segment active" type="button" aria-pressed="true">Pan map</button>
           <button id="paint-mode" class="segment" type="button" aria-pressed="false">Paint cells</button>

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -6,7 +6,7 @@ hide:
 ---
 # Set up repeater regions
 
-Find your repeater region and settings.
+Choose the forwarding paths for this repeater. Add cross-province or U.S. paths when needed.
 
 <div data-mcc-regions="config" data-mcc-root="./"></div>
 

--- a/docs/config/map.md
+++ b/docs/config/map.md
@@ -6,7 +6,7 @@ hide:
 
 # Canadian region map
 
-Search or browse Canadian regions.
+Browse Canadian boundaries and build multi-region repeater paths.
 
 <div data-mcc-regions="map" data-mcc-root="../"></div>
 

--- a/docs/config/standard.md
+++ b/docs/config/standard.md
@@ -9,11 +9,11 @@ This standard defines one Canada-wide region system: how every location is assig
 | Standard | Value |
 | --- | --- |
 | Identifier | MCC-REG-1 |
-| Version | 1.0 proposed |
+| Version | 1.1 proposed |
 | Geographic reference | Statistics Canada 2021 Census geography |
 | Current semantic input | Canada MeshCore Region Strategy v1.1.1 |
 | Current community boundary input | MeshMapper Canada snapshot, 2026-07-12 |
-| Current operational evidence | Privacy-safe MeshCore Canada radio-density snapshot, 2026-07-15 UTC |
+| Current operational evidence | Privacy-safe Canadian radio-density snapshot, 2026-07-15 UTC; aggregate Canada–U.S. route snapshot, 2026-07-18 |
 | Adoption | Becomes normative when approved and merged by MeshCore Canada |
 
 !!! important "What is authoritative today?"
@@ -25,7 +25,7 @@ MeshCore Canada maintains **one geographic partition**. Every part of Canada bel
 
 The published MeshCore Canada registry is the single source of truth. A boundary is not stored as a hand-drawn polygon. It is stored as ownership of official Statistics Canada geographic cells, then regenerated from those cells. Census Subdivisions keep a municipality or municipal equivalent together by default; Dissemination Areas remain the exact geometry used to publish the shared edge.
 
-Only leaves own land. Provinces, territories, and larger region records are grouping nodes derived from their children. Raw MeshMapper polygons, strategy circles, shared routing scopes, and event areas are never published as regions and are never added to generated commands.
+Only leaves own land. Provinces, territories, and larger region records are grouping nodes derived from their children. Raw MeshMapper polygons, strategy circles, and event areas are never published as regions. A shared repeater area is configuration metadata, not another map layer.
 
 ## Canonical model
 
@@ -52,15 +52,63 @@ Every record has separate fields for:
 
 Names, tags, and geometry may change through review. The immutable ID does not.
 
-### Cross-boundary names
+### Cross-province repeater areas
 
-A familiar name may refer to more than one adjacent leaf, but it does not create another region:
+A provincial border separates map ownership, not radio traffic. Every location still has one home leaf, but one repeater may carry several complete leaf paths when its normal coverage crosses a province or territory.
 
-- National Capital Region is a search grouping for Ottawa and Outaouais;
-- Lloydminster is split into `lloyd-ab` and `lloyd-sk` at the provincial boundary;
-- Pacific Northwest, Lake Ontario, and event names may be documented as coordination terms only.
+A **shared repeater area** records an established cross-jurisdiction community. It has a label and member leaves, but no polygon, parent, resolver result, or on-air tag of its own. The configurator emits the complete path for every member instead:
 
-Search groupings have no polygon, parent relationship, resolver result, or generated command. A search for one shows its member leaves and asks the user to choose the correct side.
+- National Capital Region: `can → on → on-alg → ott` and `can → qc → gatout`;
+- Lloydminster: `can → ab → lloyd-ab` and `can → sk → lloyd-sk`.
+
+For firmware v1.16+, the National Capital Region becomes:
+
+```text
+region def can on on-alg ott|can qc gatout
+```
+
+The `ncr` search name is not sent over the air. Both sides keep their canonical tags, and every repeater in the shared area receives the same ordered tree.
+
+This rule applies everywhere in Canada:
+
+1. A registered shared area is selected automatically for each member leaf.
+2. A large-coverage or border repeater outside a registered area may select any verified set of Canadian leaves, including leaves in different provinces or territories.
+3. Commands contain the union of the selected leaf paths. Shared ancestors appear once, parents appear before children, and each new branch jumps back to an ancestor that already exists.
+4. The configurator must fail closed if the result exceeds the firmware limits of 32 tags or 172 response bytes. No generated CLI line may exceed 160 characters; if one `region def` line would be too long, the configurator uses ordered `region put` lines instead.
+5. Adding a shared area never moves a census cell, joins polygons, or weakens the non-overlap checks.
+
+Register an automatic shared area only when operators on every side confirm routine cross-border paths or one continuous community. Other long paths are selected per repeater. This keeps defaults useful without turning every provincial boundary into one oversized radio area.
+
+### Large and neighbouring network paths
+
+A region path is a forwarding choice, not a prediction of RF range. Large coverage does not require a mountain. Elevation, water paths, ordinary rooftop sites, and linked repeaters can all produce long routes.
+
+Every repeater keeps one Canadian home region. Operators may then add complete Canadian or neighbouring U.S. paths that the repeater should forward. Region matching is exact, so every intended scope needs its complete ancestry. The configurator never adds a neighbouring path automatically and never draws U.S. geometry.
+
+Use the smallest useful set and spread work across repeaters:
+
+| Repeater role | Forwarding choice |
+| --- | --- |
+| Local access | Home path only |
+| Regional bridge | Home path plus the few neighbouring Canadian paths it routinely connects |
+| Long-haul backbone | A reviewed set of Canadian and U.S. paths supported by observed routes |
+
+Do not put every available path on every repeater. For example, traffic between Waterloo, Toronto, and Western New York can be divided among bridge repeaters instead of making each repeater carry all three paths. The choice belongs to local operators and must be coordinated with the communities that use those paths.
+
+A U.S. path is eligible when it is next to Canada or across shared water and appears in resolved route evidence. A farther path requires repeated resolved route evidence. Evidence only makes a path available; it does not make the path a default or prove future performance.
+
+The 2026-07-18 aggregate route snapshot supports these paths:
+
+| Area | Exact path | Status | Canadian side | Route patterns / observations |
+| --- | --- | --- | --- | ---: |
+| Western New York | `us → us-ny` | Documented by WNY operators | Ontario and Québec | 4,508 / 33,820 |
+| Washington | `west → pnw → wa` | Documented PNW path | British Columbia | 5,384 / 21,596 |
+| Oregon | `west → pnw → or` | Documented PNW path; farther route | British Columbia | 903 / 1,394 |
+| Pennsylvania | `us → us-pa` | Provisional; confirm locally | Ontario | 37 / 82 |
+| Ohio | `us → us-oh` | Provisional; confirm locally | Ontario | 6 / 10 |
+| California | `west → ca` | Provisional PNW extension; farther route | British Columbia | 7 / 12 |
+
+The snapshot counts unique resolved route patterns and their observations from `dev.meshcore.ca`. It stores no node names, identifiers, or exact coordinates. Counts are routing evidence, not a performance benchmark. Border or farther states may be added later only with the same evidence and neighbouring-operator review.
 
 ### Selecting a larger region
 
@@ -328,7 +376,7 @@ The editor's own census-cell geometry (`docs/assets/regions/cells/`) was last re
 Versioning rules:
 
 - **Major:** census-geography vintage or incompatible authority/model change.
-- **Minor:** DA reassignment, split, merge, hierarchy change, or tag change.
+- **Minor:** DA reassignment, split, merge, hierarchy change, tag change, or shared repeater area membership change.
 - **Patch:** labels, aliases, documentation, or source metadata with no membership change.
 
 Operational region boundaries are community routing definitions. They are not legal, electoral, cadastral, treaty, title, or sovereignty claims.
@@ -345,6 +393,10 @@ A geographic release fails unless all of these are true:
 - the symmetric difference between the leaf union and the locked 57,936-DA digital union is zero at the configured precision;
 - every subregion union equals its parent membership;
 - only leaves own geometry; no `routingOverlays`, `sharedParents`, or profile-added scopes exist;
+- every shared repeater area contains canonical leaves from at least two provinces or territories, and no leaf belongs to more than one automatic shared area;
+- shared-area names never enter the on-air tree; the complete member paths fit every firmware and serial-line budget;
+- every neighbouring path is non-geographic, optional, backed by aggregate route evidence, and uses a documented or explicitly provisional external hierarchy;
+- neighbouring paths never own Canadian cells, resolve from a map point, or appear as U.S. boundary geometry;
 - every resolver test point returns exactly one leaf;
 - every active region is contiguous by shared land edge, or has a documented island/MultiPolygon exception;
 - every active tag is globally unique and within the firmware byte limit;
@@ -377,7 +429,7 @@ Before the first MCC-REG-1 geographic release is marked active, the repository m
 | `canada-region-partition.qa.json` | Release evidence, hashes, and source deviations |
 | `configuration.yml` | Firmware and radio-setting policy kept separate from geography |
 
-Generated GeoJSON is a build output. The catalog, membership table, generator configuration, and source lock are the authority inputs. Non-geographic search groups may reference leaf tags, but they never own cells, appear in the map layer, resolve from a point, or enter generated commands.
+Generated GeoJSON is a build output. The catalog, membership table, generator configuration, and source lock are the authority inputs. Non-geographic search groups never own cells, appear in the map layer, or resolve from a point. A shared repeater area's group name never enters a command; only the canonical paths of its member leaves do.
 
 ## Migration from the current map
 
@@ -389,7 +441,7 @@ Generated GeoJSON is a build output. The catalog, membership table, generator co
 | Local review | Alberta and other fuzzy hub areas corrected; names reviewed in both official languages | Reviewed |
 | Active release | Membership and artifacts pass every release check | Authoritative |
 
-MeshMapper remains the main community assignment source where it has a region. Circles and raw source polygons are never promoted or rendered as final regions. Ottawa and Outaouais remain adjacent provincial leaves, Lloydminster is split into `lloyd-ab` and `lloyd-sk`, and shared names remain search-only groupings.
+MeshMapper remains the main community assignment source where it has a region. Circles and raw source polygons are never promoted or rendered as final regions. Ottawa and Outaouais remain adjacent provincial leaves, and Lloydminster remains split into `lloyd-ab` and `lloyd-sk`. Their shared repeater configurations join canonical member paths without joining the map geometry.
 
 ## Repeater configuration rules
 
@@ -398,10 +450,14 @@ Generated instructions must follow the current [official MeshCore CLI documentat
 - Use `region def` or `region put` to define the exact tree required by that repeater.
 - `name|jump` creates `name` under the current cursor and then moves the cursor to `jump`; `jump` is not the parent of `name`.
 - `region def` does not clear the current tree and may leave partial changes after an error.
+- A cross-province configuration must use one `can` root with one complete branch per selected leaf. It must not invent a second parent or a shared-area tag.
+- A neighbouring U.S. path keeps the hierarchy used by that community. It is a separate root branch and does not become part of `can`.
+- Registered shared repeater areas use the same deterministic member order on every repeater. Other large-coverage selections are ordered by canonical hierarchy, not by click order.
+- Select paths per repeater role. Do not add every path everywhere.
 - Run bare `region` to inspect the result.
 - Run `region save` only after the tree and flood permissions are correct.
 
-The setup tool must generate and test commands from registry parent IDs. It must never infer command order by splitting a tag string.
+The setup tool must generate and test commands from registry parent IDs. It must never infer command order by splitting a tag string. The map may outline all selected Canadian leaves together, but each fill remains its original non-overlapping geographic region. Neighbouring U.S. paths appear in commands and labels only. The boundary editor continues to accept one province or territory per proposal; shared repeater membership and neighbouring path metadata are changed in the catalog and reviewed by every affected side.
 
 ## Source record
 
@@ -411,3 +467,5 @@ The setup tool must generate and test commands from registry parent IDs. It must
 - [Statistics Canada 2021 DA definition](https://www12.statcan.gc.ca/census-recensement/2021/ref/dict/az/definition-eng.cfm?ID=geo021), [2021 Boundary Files guide](https://www150.statcan.gc.ca/n1/pub/92-160-g/92-160-g2021001-eng.htm), [2021 dissemination-geography relationships](https://www12.statcan.gc.ca/census-recensement/2021/geo/sip-pis/dguid-idugd/index2021-eng.cfm?year=21), and [2021 Economic Region standard](https://www.statcan.gc.ca/en/subjects/standard/sgc/2021/er-additionalinfo).
 - [Statistics Canada Open Licence](https://www.statcan.gc.ca/en/terms-conditions/open-licence).
 - MeshCore Canada privacy-safe positioned-node snapshot from [`live.meshcore.ca`](https://live.meshcore.ca/) and [`dev.meshcore.ca`](https://dev.meshcore.ca/), with fixed infrastructure used for decisions and all roles retained only as aggregate context.
+- Aggregate resolved-route evidence from [`dev.meshcore.ca`](https://dev.meshcore.ca/) on 2026-07-18. Only area totals are retained.
+- [WNY MeshCore radio settings](https://wnymeshcore.org/guides/radio-settings) for `us → us-ny`, the [Pacific Northwest strategy](https://gessaman.com/meshcore/regions/) for `west → pnw → wa` and `west → pnw → or`, and the [RegionMesh state-path convention](https://www.regionmesh.com/meshcore-region-configuration/) for provisional U.S. state paths.

--- a/docs/config/standard.md
+++ b/docs/config/standard.md
@@ -83,7 +83,7 @@ Register an automatic shared area only when operators on every side confirm rout
 
 A region path is a forwarding choice, not a prediction of RF range. Large coverage does not require a mountain. Elevation, water paths, ordinary rooftop sites, and linked repeaters can all produce long routes.
 
-Every repeater keeps one Canadian home region. Operators may then add complete Canadian or neighbouring U.S. paths that the repeater should forward. Region matching is exact, so every intended scope needs its complete ancestry. The configurator never adds a neighbouring path automatically and never draws U.S. geometry.
+Every repeater keeps one Canadian home region. Operators may then add complete Canadian or neighbouring U.S. paths that the repeater should forward. Region matching is exact, so every intended scope needs its complete ancestry. The configurator never adds a neighbouring path automatically and never draws U.S. geometry. Hearing traffic from an area is not enough by itself; add its path only when this repeater is meant to forward traffic scoped to that area.
 
 Use the smallest useful set and spread work across repeaters:
 

--- a/instructions.md
+++ b/instructions.md
@@ -54,6 +54,9 @@ The API accepts two strict schemas:
 The public service creates issues only. It has no Contents permission and
 cannot make a boundary live. A separate repository-owned GitHub Action applies
 an approved boundary after a maintainer closes its issue as **Completed**.
+Cross-province and U.S. forwarding choices are catalog metadata, not boundary
+edits. Operators choose them in `/config/`; the editor and submission service
+never create or modify U.S. geometry.
 The GitHub App, Turnstile account, DNS, host, TLS, secrets, repository
 installation, and Action settings must all be controlled by MeshCore Canada.
 
@@ -371,7 +374,7 @@ Use a signed-out private browser.
 ### Region boundary proposal
 
 1. Open `https://meshcore.ca/config/editor/`.
-2. Make one small valid same-province draft move.
+2. Make one small valid draft move inside one province or territory. Cross-province repeater areas are configuration records, so their map boundaries are edited one side at a time.
 3. Use reason `Production anonymous boundary test — do not apply`.
 4. Complete Turnstile and select **Submit for review**.
 5. Confirm the App-created issue has `enhancement` and `boundary-update`

--- a/instructions.md
+++ b/instructions.md
@@ -26,6 +26,42 @@ https://api.meshcore.ca:21323/api/meshcore-canada/submissions
 Do not substitute another hostname, route, or port without changing and
 reviewing both browser clients, tests, Caddy, and deployment configuration.
 
+## Pull-request responsibility split
+
+Use this split for this pull request and later submission, region, or
+configuration pull requests.
+
+Before asking for final approval, an organization administrator working from a
+trusted checkout can and should:
+
+- confirm the exact branch and commit, a clean worktree, and mergeability with
+  current `main`;
+- review the diff for secrets and unintended production or endpoint changes;
+- run the repository validation commands and confirm the required GitHub
+  checks pass;
+- verify the required label, repository secret names, maintainer allowlist,
+  branch protection, and least-privilege Action settings without reading or
+  printing secret values;
+- run the public config, CORS, and preflight checks that do not change
+  production state; and
+- push any corrections and record the tested commit and remaining host checks
+  in the pull request.
+
+The production owner must complete the steps that require MeshCore Canada host
+or provider access:
+
+- deploy and rebuild the pull-request branch when it changes the gateway,
+  container, Caddy route, or public API contract;
+- verify protected files, mounts, loopback isolation, DNS, firewall, TLS,
+  Turnstile, GitHub App installation, logs, health, and rollback on that host;
+- run the signed-out end-to-end tests against that branch deployment; and
+- give final approval, merge, switch the production checkout to clean `main`,
+  rebuild where required, and verify the live service.
+
+Do not merge or change the production checkout merely because repository and
+public read-only checks pass. Record any skipped host test and why in the pull
+request.
+
 ## What is being deployed
 
 ```text

--- a/scripts/add-meshcore-ca-broker.sh
+++ b/scripts/add-meshcore-ca-broker.sh
@@ -127,10 +127,10 @@ Ontario|YPQ|Peterborough
 Ontario|YTR|Trenton / Quinte West
 Ontario|YHD|Dryden
 Ontario|YPL|Pickle Lake
-Ontario|YND|Gatineau (Ottawa area)
 Quebec|YUL|Montreal (Trudeau)
 Quebec|YMX|Montreal (Mirabel)
 Quebec|YQB|Quebec City
+Quebec|YND|Gatineau (Ottawa area)
 Quebec|YBG|Bagotville / Saguenay
 Quebec|YVO|Val-d'Or
 Quebec|YHU|Montreal (St-Hubert)

--- a/scripts/validate-regions.js
+++ b/scripts/validate-regions.js
@@ -109,8 +109,30 @@ function ancestryFor(data, tag) {
   return result;
 }
 
+function canonicalLeafOrder(data, tags) {
+  return unique(tags).sort((left, right) => {
+    return ancestryFor(data, left).join("/").localeCompare(ancestryFor(data, right).join("/"));
+  });
+}
+
+function profileTagsForLeaves(data, leaves) {
+  return unique(canonicalLeafOrder(data, leaves).flatMap((tag) => ancestryFor(data, tag)));
+}
+
+function regionDefTokens(data, tags, parentOverrides = {}) {
+  return tags.map((tag, index) => {
+    if (index === tags.length - 1) return tag;
+    const next = tags[index + 1];
+    const nextParent = Object.prototype.hasOwnProperty.call(parentOverrides, next)
+      ? parentOverrides[next]
+      : data.hierarchy[next] && data.hierarchy[next].parent;
+    return nextParent === tag ? tag : `${tag}|${nextParent || "*"}`;
+  });
+}
+
 function validate(data, meshMapper, partition, digitalPartition, qa, municipalOverrides, radioDensity, scriptText, standardText) {
   check(data.authority && data.authority.standard === "MCC-REG-1", "catalog does not declare MCC-REG-1");
+  check(data.authority && data.authority.version === "1.1-proposed", "catalog does not declare MCC-REG-1.1");
   check(data.authority && data.authority.geographicModel === "exclusive-national-partition", "catalog is not an exclusive partition");
   check(data.authority && data.authority.currentBoundaryStatus === "generated-candidate", "boundary status must be generated-candidate");
   check(data.meta && data.meta.rootTag === "can", "root tag must be can");
@@ -149,12 +171,188 @@ function validate(data, meshMapper, partition, digitalPartition, qa, municipalOv
   check(Object.keys(data.status || {}).length === hierarchyTags.length, "status records must match hierarchy records exactly");
 
   const leafSet = new Set(leaves);
+  const sharedRepeaterMembers = new Map();
+  const sharedRepeaterProfiles = [];
+  let sharedRepeaterAreaCount = 0;
   Object.entries(data.searchGroups || {}).forEach(([name, group]) => {
+    checkExactKeys(group, new Set(["label", "members", "geographic", "emitInCommands", "repeaterConfig"]), `search group ${name}`);
     check(group.geographic === false, `search group ${name} must be explicitly non-geographic`);
-    check(group.emitInCommands === false, `search group ${name} must not enter commands`);
+    check(group.emitInCommands === false, `search group ${name} name must not enter commands`);
     check(Array.isArray(group.members) && group.members.length > 1, `search group ${name} needs at least two members`);
     (group.members || []).forEach((member) => check(leafSet.has(member), `search group ${name} references non-leaf ${member}`));
+    check(new Set(group.members || []).size === (group.members || []).length, `search group ${name} has duplicate members`);
+
+    const memberJurisdictions = unique((group.members || []).filter((member) => leafSet.has(member)).map((member) => ancestryFor(data, member)[1]));
+    if (memberJurisdictions.length > 1) {
+      check(Boolean(group.repeaterConfig), `cross-jurisdiction search group ${name} needs a shared repeater configuration`);
+    }
+    if (!group.repeaterConfig) return;
+
+    sharedRepeaterAreaCount += 1;
+    checkExactKeys(
+      group.repeaterConfig,
+      new Set(["mode", "defaultForMembers", "basis"]),
+      `search group ${name} repeaterConfig`
+    );
+    check(group.repeaterConfig.mode === "shared-member-paths", `shared repeater area ${name} has an unsupported mode`);
+    check(group.repeaterConfig.defaultForMembers === true, `shared repeater area ${name} must be the member default`);
+    check(Boolean(String(group.repeaterConfig.basis || "").trim()), `shared repeater area ${name} needs a basis`);
+    check(memberJurisdictions.length > 1, `shared repeater area ${name} must cross a province or territory`);
+    const canonicalMembers = canonicalLeafOrder(data, group.members || []);
+    check(JSON.stringify(group.members || []) === JSON.stringify(canonicalMembers), `shared repeater area ${name} members are not in canonical hierarchy order`);
+    canonicalMembers.forEach((member) => {
+      check(!sharedRepeaterMembers.has(member), `${member} belongs to more than one default shared repeater area`);
+      sharedRepeaterMembers.set(member, name);
+    });
+
+    const profileTags = profileTagsForLeaves(data, canonicalMembers);
+    const responseBytes = Buffer.byteLength(profileTags.join(","), "utf8") + 1;
+    const defLine = `region def ${regionDefTokens(data, profileTags).join(" ")}`;
+    check(profileTags.length <= MAX_PROFILE_TAGS, `shared repeater area ${name} exceeds ${MAX_PROFILE_TAGS} tags`);
+    check(responseBytes <= MAX_RESPONSE_BYTES, `shared repeater area ${name} exceeds ${MAX_RESPONSE_BYTES} response bytes`);
+    check(defLine.length <= MAX_REGION_DEF_CHARS, `shared repeater area ${name} exceeds the ${MAX_REGION_DEF_CHARS}-character region def limit`);
+    check(!profileTags.includes(name), `shared repeater area ${name} incorrectly emits its group name`);
+    sharedRepeaterProfiles.push({
+      name,
+      tags: profileTags.length,
+      responseBytes,
+      defChars: defLine.length
+    });
   });
+
+  const expectedExternalPaths = {
+    "western-new-york": ["us", "us-ny"],
+    washington: ["west", "pnw", "wa"],
+    oregon: ["west", "pnw", "or"],
+    pennsylvania: ["us", "us-pa"],
+    ohio: ["us", "us-oh"],
+    california: ["west", "ca"]
+  };
+  const expectedDocumentedPaths = new Set(["western-new-york", "washington", "oregon"]);
+  const externalEntries = Object.entries(data.externalRegionPaths || {});
+  const externalParents = new Map();
+  const externalLabels = new Map();
+  const externalProfiles = [];
+  check(
+    JSON.stringify(externalEntries.map(([id]) => id).sort()) ===
+      JSON.stringify(Object.keys(expectedExternalPaths).sort()),
+    "neighbouring paths must match the current traffic-evidenced set"
+  );
+  externalEntries.forEach(([id, record]) => {
+    checkExactKeys(
+      record,
+      new Set([
+        "label", "country", "areaCode", "path", "tagLabels", "geographic",
+        "automatic", "eligibility", "authority", "trafficEvidence"
+      ]),
+      `neighbouring path ${id}`
+    );
+    check(Boolean(String(record.label || "").trim()), `neighbouring path ${id} needs a label`);
+    check(record.country === "us", `neighbouring path ${id} must identify country us`);
+    check(/^[A-Z]{2}$/.test(String(record.areaCode || "")), `neighbouring path ${id} has an invalid area code`);
+    check(record.geographic === false, `neighbouring path ${id} must be non-geographic`);
+    check(record.automatic === false, `neighbouring path ${id} must never be automatic`);
+    check(
+      ["border-or-shared-water", "observed-further-route"].includes(record.eligibility),
+      `neighbouring path ${id} has an invalid eligibility rule`
+    );
+
+    const externalPath = Array.isArray(record.path) ? record.path : [];
+    check(
+      JSON.stringify(externalPath) === JSON.stringify(expectedExternalPaths[id] || []),
+      `neighbouring path ${id} does not match its reviewed hierarchy`
+    );
+    check(externalPath.length >= 2, `neighbouring path ${id} needs a complete path`);
+    check(unique(externalPath).length === externalPath.length, `neighbouring path ${id} repeats a tag`);
+    checkExactKeys(record.tagLabels, new Set(externalPath), `neighbouring path ${id} tagLabels`);
+    externalPath.forEach((tag, index) => {
+      check(TAG_RE.test(tag), `neighbouring path ${id} has invalid tag ${tag}`);
+      check(Buffer.byteLength(tag, "utf8") <= MAX_TAG_BYTES, `neighbouring tag exceeds ${MAX_TAG_BYTES} bytes: ${tag}`);
+      check(!Object.prototype.hasOwnProperty.call(data.hierarchy, tag), `neighbouring tag collides with Canadian hierarchy: ${tag}`);
+      check(Boolean(String(record.tagLabels && record.tagLabels[tag] || "").trim()), `neighbouring path ${id} has no label for ${tag}`);
+      const parent = index ? externalPath[index - 1] : null;
+      if (externalParents.has(tag)) {
+        check(externalParents.get(tag) === parent, `neighbouring tag ${tag} has conflicting parents`);
+      } else {
+        externalParents.set(tag, parent);
+      }
+      if (externalLabels.has(tag)) {
+        check(externalLabels.get(tag) === record.tagLabels[tag], `neighbouring tag ${tag} has conflicting labels`);
+      } else {
+        externalLabels.set(tag, record.tagLabels[tag]);
+      }
+    });
+
+    checkExactKeys(record.authority, new Set(["status", "source", "sourceUrl"]), `neighbouring path ${id} authority`);
+    const expectedStatus = expectedDocumentedPaths.has(id) ? "documented" : "provisional";
+    check(record.authority && record.authority.status === expectedStatus, `neighbouring path ${id} has the wrong review status`);
+    check(Boolean(String(record.authority && record.authority.source || "").trim()), `neighbouring path ${id} needs an authority source`);
+    check(/^https:\/\//.test(String(record.authority && record.authority.sourceUrl || "")), `neighbouring path ${id} needs an HTTPS authority URL`);
+
+    checkExactKeys(
+      record.trafficEvidence,
+      new Set(["source", "snapshot", "method", "routePatterns", "observations"]),
+      `neighbouring path ${id} trafficEvidence`
+    );
+    check(record.trafficEvidence && record.trafficEvidence.source === "https://dev.meshcore.ca/", `neighbouring path ${id} has the wrong traffic source`);
+    check(/^\d{4}-\d{2}-\d{2}$/.test(String(record.trafficEvidence && record.trafficEvidence.snapshot || "")), `neighbouring path ${id} has an invalid snapshot date`);
+    check(record.trafficEvidence && record.trafficEvidence.method === "mixed-canada-us-resolved-route", `neighbouring path ${id} has an invalid evidence method`);
+    check(Number.isInteger(record.trafficEvidence && record.trafficEvidence.routePatterns) && record.trafficEvidence.routePatterns > 0, `neighbouring path ${id} needs positive route-pattern evidence`);
+    check(Number.isInteger(record.trafficEvidence && record.trafficEvidence.observations) && record.trafficEvidence.observations > 0, `neighbouring path ${id} needs positive route observations`);
+
+    const parentOverrides = Object.fromEntries(externalPath.map((tag) => [tag, externalParents.get(tag)]));
+    const responseBytes = Buffer.byteLength(externalPath.join(","), "utf8") + 1;
+    const defLine = `region def ${regionDefTokens(data, externalPath, parentOverrides).join(" ")}`;
+    check(externalPath.length <= MAX_PROFILE_TAGS, `neighbouring path ${id} exceeds ${MAX_PROFILE_TAGS} tags`);
+    check(responseBytes <= MAX_RESPONSE_BYTES, `neighbouring path ${id} exceeds ${MAX_RESPONSE_BYTES} response bytes`);
+    check(defLine.length <= MAX_REGION_DEF_CHARS, `neighbouring path ${id} exceeds the ${MAX_REGION_DEF_CHARS}-character region def limit`);
+    externalProfiles.push({ name: id, tags: externalPath.length, responseBytes, defChars: defLine.length });
+  });
+
+  const representativeCanadianLeaves = ["tor", "wat"];
+  representativeCanadianLeaves.forEach((tag) => check(leafSet.has(tag), `missing representative Canadian leaf ${tag}`));
+  const representativeExternal = data.externalRegionPaths && data.externalRegionPaths["western-new-york"];
+  if (representativeCanadianLeaves.every((tag) => leafSet.has(tag)) && representativeExternal) {
+    const localTags = profileTagsForLeaves(data, representativeCanadianLeaves);
+    const tags = unique(localTags.concat(representativeExternal.path));
+    const overrides = Object.fromEntries(representativeExternal.path.map((tag, index) => [
+      tag,
+      index ? representativeExternal.path[index - 1] : null
+    ]));
+    const command = `region def ${regionDefTokens(data, tags, overrides).join(" ")}`;
+    check(
+      command === "region def can on on-gtha gta tor|on on-ktw wat|* us us-ny",
+      `representative Ontario-WNY command is wrong: ${command}`
+    );
+    externalProfiles.push({
+      name: "ontario-wny-fixture",
+      tags: tags.length,
+      responseBytes: Buffer.byteLength(tags.join(","), "utf8") + 1,
+      defChars: command.length
+    });
+  }
+
+  if (leafSet.has("mvrd") && externalEntries.length) {
+    const records = externalEntries.map(([, record]) => record).sort((left, right) => {
+      return left.path.join("/").localeCompare(right.path.join("/"));
+    });
+    const tags = unique(profileTagsForLeaves(data, ["mvrd"]).concat(records.flatMap((record) => record.path)));
+    const overrides = {};
+    records.forEach((record) => record.path.forEach((tag, index) => {
+      overrides[tag] = index ? record.path[index - 1] : null;
+    }));
+    const command = `region def ${regionDefTokens(data, tags, overrides).join(" ")}`;
+    const responseBytes = Buffer.byteLength(tags.join(","), "utf8") + 1;
+    check(tags.length <= MAX_PROFILE_TAGS, `all current neighbouring paths exceed ${MAX_PROFILE_TAGS} tags`);
+    check(responseBytes <= MAX_RESPONSE_BYTES, `all current neighbouring paths exceed ${MAX_RESPONSE_BYTES} response bytes`);
+    check(command.length <= MAX_REGION_DEF_CHARS, `all current neighbouring paths exceed the ${MAX_REGION_DEF_CHARS}-character region def limit`);
+    externalProfiles.push({
+      name: "all-neighbouring-paths-fixture",
+      tags: tags.length,
+      responseBytes,
+      defChars: command.length
+    });
+  }
 
   const aliasOwners = new Map();
   Object.entries(data.aliases || {}).forEach(([owner, aliases]) => {
@@ -539,12 +737,35 @@ function validate(data, meshMapper, partition, digitalPartition, qa, municipalOv
     check(responseBytes <= MAX_RESPONSE_BYTES, `${tag} path exceeds ${MAX_RESPONSE_BYTES} response bytes`);
     check(defChars <= MAX_REGION_DEF_CHARS, `${tag} region def exceeds ${MAX_REGION_DEF_CHARS} characters`);
   });
+  sharedRepeaterProfiles.forEach((profile) => {
+    maxTags = Math.max(maxTags, profile.tags);
+    maxResponseBytes = Math.max(maxResponseBytes, profile.responseBytes);
+    maxRegionDefChars = Math.max(maxRegionDefChars, profile.defChars);
+  });
+  externalProfiles.forEach((profile) => {
+    maxTags = Math.max(maxTags, profile.tags);
+    maxResponseBytes = Math.max(maxResponseBytes, profile.responseBytes);
+    maxRegionDefChars = Math.max(maxRegionDefChars, profile.defChars);
+  });
 
   check(!scriptText.includes("region dump"), "obsolete 'region dump' command remains in regions.js");
   check(scriptText.includes('verificationCommands = ["region"]'), "guided verification must use bare region command");
   check(scriptText.includes('commands.concat(["region", "region save", "region"])'), "technical flow must verify before and after saving");
-  check(scriptText.includes("Run <code>region</code> and confirm:"), "guided flow must verify before saving");
+  check(scriptText.includes("Run <code>region</code> and confirm"), "guided flow must verify before saving");
   check(scriptText.includes("Too many regions selected"), "command generation must fail closed on firmware limits");
+  check(
+    scriptText.includes("if (regionDefLine.length <= 160)") &&
+      scriptText.includes('lines.push(parent ? "region put " + tag + " " + parent : "region put " + tag)'),
+    "command generation must fall back to bounded region put lines"
+  );
+  check(scriptText.includes("Provinces and territories may be mixed."), "wide-coverage UI does not support cross-province selection");
+  check(scriptText.includes("Large or cross-border coverage"), "UI does not offer large and cross-border forwarding");
+  check(scriptText.includes("Different repeaters can carry different paths to spread traffic."), "UI does not explain path distribution");
+  check(scriptText.includes("Neighbouring network paths"), "UI does not expose traffic-evidenced U.S. paths");
+  check(scriptText.includes("requestedExternalPaths"), "map does not restore neighbouring path selections");
+  check(scriptText.includes("is-external"), "UI does not distinguish neighbouring tags");
+  check(scriptText.includes("Shared repeater area"), "UI does not identify shared repeater configurations");
+  check(scriptText.includes("shared-member-paths"), "UI does not load shared repeater area definitions");
   check(scriptText.includes('"canada-region-partition.geojson"'), "UI does not load the generated partition");
   check(scriptText.includes('"canada-region-partition-digital.geojson"'), "UI does not load the complete resolver partition");
   check(!scriptText.includes('fetch(new URL("meshmapper-canada-regions.json"'), "UI must not load raw MeshMapper polygons");
@@ -565,7 +786,19 @@ function validate(data, meshMapper, partition, digitalPartition, qa, municipalOv
     "Boundary editor proposals",
     "positive-area overlap",
     "canada-region-membership.csv",
-    "Run bare `region`"
+    "Run bare `region`",
+    "Cross-province repeater areas",
+    "Large and neighbouring network paths",
+    "Large coverage does not require a mountain",
+    "Do not put every available path on every repeater",
+    "Western New York",
+    "`west → pnw → or`",
+    "never draws U.S. geometry",
+    "shared repeater area",
+    "region def can on on-alg ott|can qc gatout",
+    "32 tags",
+    "172 response bytes",
+    "No generated CLI line may exceed 160 characters"
   ].forEach((phrase) => check(standardText.includes(phrase), `standard is missing required rule: ${phrase}`));
 
   return {
@@ -581,6 +814,8 @@ function validate(data, meshMapper, partition, digitalPartition, qa, municipalOv
     meshMapperInputs: sourceFeatures.length,
     meshMapperCanonicalTags: mappedCanonical.size,
     searchGroups: Object.keys(data.searchGroups || {}).length,
+    sharedRepeaterAreas: sharedRepeaterAreaCount,
+    externalRegionPaths: externalEntries.length,
     ambiguousAliases: ambiguousAliases.length,
     maxTags,
     maxResponseBytes,

--- a/tests/editor/shared-repeater-areas.test.mjs
+++ b/tests/editor/shared-repeater-areas.test.mjs
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import { runInNewContext } from "node:vm";
 
 const catalog = JSON.parse(await readFile(
   new URL("../../docs/assets/regions/canada-regions.json", import.meta.url),
@@ -14,6 +15,40 @@ const editorHtml = await readFile(
   new URL("../../docs/config/editor/index.html", import.meta.url),
   "utf8"
 );
+
+function regionInternals() {
+  const marker = "  if (window.document$";
+  assert.ok(regionsScript.includes(marker));
+  const instrumented = regionsScript.replace(
+    marker,
+    "  globalThis.__mccRegionTest = { prepareCatalog, expandSharedRepeaterLeaves, recommend };\n\n" + marker
+  );
+  const context = {
+    URL,
+    URLSearchParams,
+    console,
+    fetch() {
+      throw new Error("Unexpected asset request in unit test");
+    },
+    window: {
+      location: {
+        origin: "https://meshcore.ca",
+        pathname: "/config/",
+        search: ""
+      },
+      setTimeout
+    },
+    document: {
+      currentScript: {
+        src: "https://meshcore.ca/assets/regions/regions.js"
+      },
+      readyState: "loading",
+      addEventListener() {}
+    }
+  };
+  runInNewContext(instrumented, context);
+  return context.__mccRegionTest;
+}
 
 function ancestry(tag) {
   const path = [];
@@ -86,6 +121,30 @@ test("every declared cross-province group uses the shared member-path policy", (
       basis: group.repeaterConfig.basis
     }, id);
     assert.equal(sharedCommand(group.members).includes(` ${id} `), false, id);
+  }
+});
+
+test("adding either shared-area member expands every member path", () => {
+  const internals = regionInternals();
+  const prepared = internals.prepareCatalog(JSON.parse(JSON.stringify(catalog)));
+  const resolution = { primary: { seed: { tag: "tor" } } };
+
+  for (const group of Object.values(catalog.searchGroups)) {
+    if (!group.repeaterConfig?.defaultForMembers) continue;
+    for (const member of group.members) {
+      const recommendation = internals.recommend(
+        prepared,
+        resolution,
+        "high-site",
+        ["tor", member],
+        []
+      );
+      const expected = ["tor", ...group.members].sort((left, right) => {
+        return ancestry(left).join("/").localeCompare(ancestry(right).join("/"));
+      });
+      assert.deepEqual(Array.from(recommendation.leaves), expected, member);
+      assert.ok(group.members.every((tag) => recommendation.tags.includes(tag)), member);
+    }
   }
 });
 

--- a/tests/editor/shared-repeater-areas.test.mjs
+++ b/tests/editor/shared-repeater-areas.test.mjs
@@ -1,0 +1,140 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const catalog = JSON.parse(await readFile(
+  new URL("../../docs/assets/regions/canada-regions.json", import.meta.url),
+  "utf8"
+));
+const regionsScript = await readFile(
+  new URL("../../docs/assets/regions/regions.js", import.meta.url),
+  "utf8"
+);
+const editorHtml = await readFile(
+  new URL("../../docs/config/editor/index.html", import.meta.url),
+  "utf8"
+);
+
+function ancestry(tag) {
+  const path = [];
+  let current = tag;
+  while (current) {
+    path.unshift(current);
+    current = catalog.hierarchy[current]?.parent;
+  }
+  return path;
+}
+
+function sharedCommand(members) {
+  const leaves = [...new Set(members)].sort((left, right) => {
+    return ancestry(left).join("/").localeCompare(ancestry(right).join("/"));
+  });
+  const tags = [...new Set(leaves.flatMap(ancestry))];
+  const tokens = tags.map((tag, index) => {
+    if (index === tags.length - 1) return tag;
+    const nextParent = catalog.hierarchy[tags[index + 1]]?.parent || "*";
+    return nextParent === tag ? tag : `${tag}|${nextParent}`;
+  });
+  return `region def ${tokens.join(" ")}`;
+}
+
+function combinedCommand(members, externalIds) {
+  const leaves = [...new Set(members)].sort((left, right) => {
+    return ancestry(left).join("/").localeCompare(ancestry(right).join("/"));
+  });
+  const external = externalIds
+    .map((id) => catalog.externalRegionPaths[id])
+    .sort((left, right) => left.path.join("/").localeCompare(right.path.join("/")));
+  const tags = [...new Set(leaves.flatMap(ancestry).concat(external.flatMap((record) => record.path)))];
+  const parentOverrides = new Map();
+  external.forEach((record) => {
+    record.path.forEach((tag, index) => parentOverrides.set(tag, index ? record.path[index - 1] : null));
+  });
+  const tokens = tags.map((tag, index) => {
+    if (index === tags.length - 1) return tag;
+    const next = tags[index + 1];
+    const nextParent = parentOverrides.has(next)
+      ? parentOverrides.get(next)
+      : catalog.hierarchy[next]?.parent;
+    return nextParent === tag ? tag : `${tag}|${nextParent || "*"}`;
+  });
+  return `region def ${tokens.join(" ")}`;
+}
+
+test("National Capital Region keeps separate map leaves and emits one multi-branch repeater tree", () => {
+  const ncr = catalog.searchGroups.ncr;
+  assert.equal(ncr.geographic, false);
+  assert.equal(ncr.emitInCommands, false);
+  assert.deepEqual(ncr.members, ["ott", "gatout"]);
+  assert.deepEqual(
+    ncr.members.map((tag) => ancestry(tag)[1]),
+    ["on", "qc"]
+  );
+  assert.equal(
+    sharedCommand(ncr.members),
+    "region def can on on-alg ott|can qc gatout"
+  );
+});
+
+test("every declared cross-province group uses the shared member-path policy", () => {
+  for (const [id, group] of Object.entries(catalog.searchGroups)) {
+    const jurisdictions = new Set(group.members.map((tag) => ancestry(tag)[1]));
+    if (jurisdictions.size < 2) continue;
+    assert.deepEqual(group.repeaterConfig, {
+      mode: "shared-member-paths",
+      defaultForMembers: true,
+      basis: group.repeaterConfig.basis
+    }, id);
+    assert.equal(sharedCommand(group.members).includes(` ${id} `), false, id);
+  }
+});
+
+test("configurator and editor expose generic cross-province behavior without merging geometry", () => {
+  assert.match(regionsScript, /Provinces and territories may be mixed\./);
+  assert.match(regionsScript, /Add any Canadian region/);
+  assert.match(regionsScript, /All map boundaries remain separate\./);
+  assert.match(editorHtml, /This editor changes Canadian map cells only\./);
+  assert.match(editorHtml, /Choose cross-province and U\.S\. paths in the configurator\./);
+});
+
+test("only traffic-evidenced neighbouring paths are offered and none is automatic geography", () => {
+  assert.deepEqual(
+    Object.keys(catalog.externalRegionPaths).sort(),
+    ["california", "ohio", "oregon", "pennsylvania", "washington", "western-new-york"]
+  );
+  for (const [id, record] of Object.entries(catalog.externalRegionPaths)) {
+    assert.equal(record.country, "us", id);
+    assert.equal(record.geographic, false, id);
+    assert.equal(record.automatic, false, id);
+    assert.ok(record.trafficEvidence.routePatterns > 0, id);
+    assert.ok(record.trafficEvidence.observations > 0, id);
+    assert.equal(record.trafficEvidence.method, "mixed-canada-us-resolved-route", id);
+  }
+  assert.deepEqual(catalog.externalRegionPaths["western-new-york"].path, ["us", "us-ny"]);
+  assert.deepEqual(catalog.externalRegionPaths.washington.path, ["west", "pnw", "wa"]);
+  assert.deepEqual(catalog.externalRegionPaths.oregon.path, ["west", "pnw", "or"]);
+});
+
+test("Ontario bridge selection emits complete Canadian and Western New York branches", () => {
+  assert.equal(
+    combinedCommand(["tor", "wat"], ["western-new-york"]),
+    "region def can on on-gtha gta tor|on on-ktw wat|* us us-ny"
+  );
+  assert.match(regionsScript, /Different repeaters can carry different paths to spread traffic\./);
+  assert.match(regionsScript, /Nothing outside Canada is added to the boundary map\./);
+  assert.match(regionsScript, /requestedExternalPaths/);
+});
+
+test("config-to-map handoff preserves large Canadian and neighbouring selections", () => {
+  assert.match(regionsScript, /params\.set\("type", "large"\)/);
+  assert.match(regionsScript, /params\.set\("regions", state\.selectedMetros\.join\(","\)\)/);
+  assert.match(regionsScript, /params\.set\("external", state\.selectedExternalPaths\.join\(","\)\)/);
+  assert.match(regionsScript, /refreshTool\(data, els, state, updateMapLinks\)/);
+  assert.match(regionsScript, /map\.fitBounds\(selectedLayer\.getBounds\(\)/);
+});
+
+test("documented neighbouring paths do not inherit Canadian draft warnings", () => {
+  assert.ok(
+    regionsScript.match(/if \(data\.externalTagLabels && data\.externalTagLabels\[tag\]\) return false;/g)?.length >= 2
+  );
+});

--- a/tests/editor/shared-repeater-areas.test.mjs
+++ b/tests/editor/shared-repeater-areas.test.mjs
@@ -180,6 +180,7 @@ test("Ontario bridge selection emits complete Canadian and Western New York bran
     "region def can on on-gtha gta tor|on on-ktw wat|* us us-ny"
   );
   assert.match(regionsScript, /Different repeaters can carry different paths to spread traffic\./);
+  assert.match(regionsScript, /Add one only when this repeater should forward traffic for that area\./);
   assert.match(regionsScript, /Nothing outside Canada is added to the boundary map\./);
   assert.match(regionsScript, /requestedExternalPaths/);
 });

--- a/tools/region-proposal-gateway/README.md
+++ b/tools/region-proposal-gateway/README.md
@@ -75,7 +75,8 @@ The server revalidates every boundary proposal against the mounted authority:
 - membership DGUIDs must be unique and match the per-province TopoJSON cells;
 - every leaf must retain exactly one anchor;
 - the submitted base hash and every `from` value must still be current;
-- target leaves must be valid and in the same province or territory;
+- target leaves must be valid and in the same province or territory; shared cross-province repeater configurations do not move map cells;
+- neighbouring U.S. forwarding paths are catalog metadata and are never boundary-editor geometry;
 - anchors cannot move; and
 - request, proposal, and changed-cell limits must pass.
 


### PR DESCRIPTION
## Summary

- keep Canada as one complete, non-overlapping geographic layer while allowing repeaters to forward more than one canonical path
- configure the National Capital Region and Lloydminster as shared member paths without merging their provincial map geometry
- add a **Large or cross-border coverage** flow where operators choose only the Canadian and neighbouring paths each repeater should carry
- preserve the selected paths between `/config/` and `/config/map/`, outline all selected Canadian leaves, and keep U.S. paths command-only
- update `/config/standard/` and `/config/editor/` so large coverage is not tied to mountains and forwarding work can be distributed across local, bridge, and backbone repeaters
- correct YND/Gatineau from Ontario to Quebec in the analyzer references

## Neighbouring path set

Only U.S. areas with observed Canada–U.S. resolved routes are offered. None is automatic and none adds U.S. boundary geometry. Hearing a path is not enough by itself; operators add it only when that repeater should forward traffic scoped to the area.

Documented community paths:

- Western New York: `us → us-ny`
- Washington: `west → pnw → wa`
- Oregon: `west → pnw → or`

Provisional paths that require local confirmation:

- Pennsylvania: `us → us-pa`
- Ohio: `us → us-oh`
- California: `west → ca`

The catalog records privacy-safe aggregate route-pattern and observation counts from the 2026-07-18 `dev.meshcore.ca` snapshot. No node identifiers, names, or exact coordinates are committed.

## Behaviour

- each location still resolves to exactly one Canadian leaf
- established cross-province communities may receive a deterministic shared default
- other large Canadian or U.S. paths are selected per repeater
- complete ancestry is emitted for exact region matching
- generated profiles fail closed at 32 tags / 172 response bytes and fall back to ordered `region put` lines if a `region def` line would exceed 160 characters
- the map handoff restores large-mode, Canadian leaves, and neighbouring paths

## Validation

- `node scripts/validate-regions.js`
- `node --test tests/editor/*.test.mjs` — 47 passed
- gateway tests — 35 passed, 1 expected Windows skip
- approval automation tests — 14 passed
- display and digital geometry verification — 193 valid leaves, 0 positive-area overlaps, all seeds resolved exactly once
- `mkdocs build --strict`
- rendered QA of configurator, generated Toronto + Waterloo + WNY command tree, map restoration, editor, and standard

This is intentionally separate from PR #57 and does not modify its boundary-preview implementation.