### PR TITLE
Install gateway dependencies before Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,9 @@ jobs:
         run: |
           pip install mkdocs-macros-plugin pyyaml mkdocs-glightbox pymdown-extensions shapely==2.0.6 mkdocs-redirects==1.2.2
 
+      - name: Install proposal gateway dependencies
+        run: python -m pip install -r tools/region-proposal-gateway/requirements.txt
+
       - name: Validate MeshCore Canada proposal service
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- install the proposal gateway's pinned Python requirements before the deployment workflow runs its gateway tests
- keep deployment validation aligned with the pull-request validation workflow

## Root cause

The merge-triggered Pages deployments for PRs #57 and #58 failed before the build because `test_gateway.py` imports Pillow, but `.github/workflows/deploy.yml` did not install `tools/region-proposal-gateway/requirements.txt`. The validation workflow already installs this exact pinned requirements file.

## Validation

- parsed `.github/workflows/deploy.yml` with PyYAML
- gateway tests: 42 passed, 1 expected Windows-only POSIX permission skip
- approval automation: 14 passed
- editor/browser-contract tests: 47 passed
- both geometry checks: 193 valid leaves, zero positive-area overlaps, all seeds resolved once
- region and community-submission validation passed
- JavaScript syntax checks passed
- `mkdocs build --strict`
- `git diff --check`