### PR TITLE
Keep boundary previews working without Pillow

### DIFF
--- a/tools/region-proposal-gateway/README.md
+++ b/tools/region-proposal-gateway/README.md
@@ -250,8 +250,11 @@ text, Turnstile tokens, App tokens, or secrets.
 
 ## Tests
 
-No live credentials are required. Install the pinned renderer dependency, then
-run:
+No live credentials are required. The container installs the pinned Pillow
+renderer. The gateway also includes a deterministic standard-library PNG
+renderer so a minimal host Python cannot take the submission API offline; the
+same Current/Proposed boundary contract remains available. Install the pinned
+dependency to exercise both paths, then run:
 
 ```sh
 python -m pip install -r tools/region-proposal-gateway/requirements.txt

--- a/tools/region-proposal-gateway/boundary_preview.py
+++ b/tools/region-proposal-gateway/boundary_preview.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import binascii
 import io
 import math
+import struct
+import zlib
 from collections import Counter
 from typing import Any, Mapping
 
-from PIL import Image, ImageDraw, ImageFont
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError:  # The gateway remains usable on a minimal host install.
+    Image = None
+    ImageDraw = None
+    ImageFont = None
 
 
 IMAGE_WIDTH = 1600
@@ -49,6 +57,346 @@ REGION_PALETTE = (
 
 class PreviewRenderError(RuntimeError):
     """The trusted authority geometry could not produce a safe preview."""
+
+
+_FONT_5X7 = {
+    " ": (0, 0, 0, 0, 0, 0, 0),
+    "A": (14, 17, 17, 31, 17, 17, 17),
+    "B": (30, 17, 17, 30, 17, 17, 30),
+    "C": (14, 17, 16, 16, 16, 17, 14),
+    "D": (30, 17, 17, 17, 17, 17, 30),
+    "E": (31, 16, 16, 30, 16, 16, 31),
+    "F": (31, 16, 16, 30, 16, 16, 16),
+    "G": (14, 17, 16, 23, 17, 17, 14),
+    "H": (17, 17, 17, 31, 17, 17, 17),
+    "I": (14, 4, 4, 4, 4, 4, 14),
+    "J": (7, 2, 2, 2, 2, 18, 12),
+    "K": (17, 18, 20, 24, 20, 18, 17),
+    "L": (16, 16, 16, 16, 16, 16, 31),
+    "M": (17, 27, 21, 21, 17, 17, 17),
+    "N": (17, 25, 21, 19, 17, 17, 17),
+    "O": (14, 17, 17, 17, 17, 17, 14),
+    "P": (30, 17, 17, 30, 16, 16, 16),
+    "Q": (14, 17, 17, 17, 21, 18, 13),
+    "R": (30, 17, 17, 30, 20, 18, 17),
+    "S": (15, 16, 16, 14, 1, 1, 30),
+    "T": (31, 4, 4, 4, 4, 4, 4),
+    "U": (17, 17, 17, 17, 17, 17, 14),
+    "V": (17, 17, 17, 17, 17, 10, 4),
+    "W": (17, 17, 17, 21, 21, 21, 10),
+    "X": (17, 17, 10, 4, 10, 17, 17),
+    "Y": (17, 17, 10, 4, 4, 4, 4),
+    "Z": (31, 1, 2, 4, 8, 16, 31),
+    "0": (14, 17, 19, 21, 25, 17, 14),
+    "1": (4, 12, 4, 4, 4, 4, 14),
+    "2": (14, 17, 1, 2, 4, 8, 31),
+    "3": (30, 1, 1, 14, 1, 1, 30),
+    "4": (2, 6, 10, 18, 31, 2, 2),
+    "5": (31, 16, 16, 30, 1, 1, 30),
+    "6": (14, 16, 16, 30, 17, 17, 14),
+    "7": (31, 1, 2, 4, 8, 8, 8),
+    "8": (14, 17, 17, 14, 17, 17, 14),
+    "9": (14, 17, 17, 15, 1, 1, 14),
+    "-": (0, 0, 0, 31, 0, 0, 0),
+    ".": (0, 0, 0, 0, 0, 12, 12),
+    ",": (0, 0, 0, 0, 0, 4, 8),
+    ":": (0, 4, 4, 0, 4, 4, 0),
+    "|": (4, 4, 4, 4, 4, 4, 4),
+    ">": (16, 8, 4, 2, 4, 8, 16),
+    "+": (0, 4, 4, 31, 4, 4, 0),
+    "/": (1, 2, 2, 4, 8, 8, 16),
+    "?": (14, 17, 1, 2, 4, 0, 4),
+}
+
+
+def _rgb(colour: str) -> tuple[int, int, int]:
+    if len(colour) != 7 or not colour.startswith("#"):
+        raise PreviewRenderError("the boundary preview contains an invalid colour")
+    try:
+        return tuple(int(colour[index:index + 2], 16) for index in (1, 3, 5))
+    except ValueError as exc:
+        raise PreviewRenderError("the boundary preview contains an invalid colour") from exc
+
+
+class _StdlibRaster:
+    """Small deterministic RGB raster used when Pillow is unavailable."""
+
+    def __init__(self, width: int, height: int, background: str):
+        self.width = width
+        self.height = height
+        self.pixels = bytearray(bytes(_rgb(background)) * (width * height))
+
+    def _set(self, x: int, y: int, colour: tuple[int, int, int]) -> None:
+        if 0 <= x < self.width and 0 <= y < self.height:
+            offset = (y * self.width + x) * 3
+            self.pixels[offset:offset + 3] = colour
+
+    def rectangle(
+        self,
+        box: tuple[int, int, int, int],
+        *,
+        fill: str | None = None,
+        outline: str | None = None,
+        width: int = 1,
+    ) -> None:
+        left, top, right, bottom = box
+        left = max(0, min(self.width - 1, left))
+        right = max(0, min(self.width - 1, right))
+        top = max(0, min(self.height - 1, top))
+        bottom = max(0, min(self.height - 1, bottom))
+        if left > right or top > bottom:
+            return
+        if fill is not None:
+            colour = bytes(_rgb(fill))
+            row = colour * (right - left + 1)
+            for y in range(top, bottom + 1):
+                offset = (y * self.width + left) * 3
+                self.pixels[offset:offset + len(row)] = row
+        if outline is not None and width > 0:
+            colour = _rgb(outline)
+            for offset in range(width):
+                self.line((left + offset, top + offset), (right - offset, top + offset), colour)
+                self.line((left + offset, bottom - offset), (right - offset, bottom - offset), colour)
+                self.line((left + offset, top + offset), (left + offset, bottom - offset), colour)
+                self.line((right - offset, top + offset), (right - offset, bottom - offset), colour)
+
+    def line(
+        self,
+        start: tuple[int, int],
+        end: tuple[int, int],
+        colour: str | tuple[int, int, int],
+        width: int = 1,
+    ) -> None:
+        rgb = _rgb(colour) if isinstance(colour, str) else colour
+        x0, y0 = start
+        x1, y1 = end
+        dx = abs(x1 - x0)
+        dy = -abs(y1 - y0)
+        sx = 1 if x0 < x1 else -1
+        sy = 1 if y0 < y1 else -1
+        error = dx + dy
+        radius = max(0, width - 1) // 2
+        while True:
+            for py in range(y0 - radius, y0 + radius + 1):
+                for px in range(x0 - radius, x0 + radius + 1):
+                    self._set(px, py, rgb)
+            if x0 == x1 and y0 == y1:
+                break
+            doubled = 2 * error
+            if doubled >= dy:
+                error += dy
+                x0 += sx
+            if doubled <= dx:
+                error += dx
+                y0 += sy
+
+    def paste(self, source: "_StdlibRaster", position: tuple[int, int]) -> None:
+        left, top = position
+        for source_y in range(source.height):
+            target_y = top + source_y
+            if not 0 <= target_y < self.height:
+                continue
+            source_left = max(0, -left)
+            source_right = min(source.width, self.width - left)
+            if source_left >= source_right:
+                continue
+            source_start = (source_y * source.width + source_left) * 3
+            source_end = (source_y * source.width + source_right) * 3
+            target_start = (target_y * self.width + left + source_left) * 3
+            self.pixels[target_start:target_start + source_end - source_start] = (
+                source.pixels[source_start:source_end]
+            )
+
+    def polygon(
+        self,
+        points: list[tuple[int, int]],
+        *,
+        fill: str,
+        outline: str,
+        width: int,
+    ) -> None:
+        if len(points) < 3:
+            return
+        minimum_y = max(0, min(point[1] for point in points))
+        maximum_y = min(self.height - 1, max(point[1] for point in points))
+        fill_rgb = bytes(_rgb(fill))
+        closed = points if points[0] == points[-1] else points + [points[0]]
+        for y in range(minimum_y, maximum_y + 1):
+            sample_y = y + 0.5
+            intersections: list[float] = []
+            for first, second in zip(closed, closed[1:]):
+                x1, y1 = first
+                x2, y2 = second
+                if (y1 <= sample_y < y2) or (y2 <= sample_y < y1):
+                    intersections.append(x1 + (sample_y - y1) * (x2 - x1) / (y2 - y1))
+            intersections.sort()
+            for index in range(0, len(intersections) - 1, 2):
+                left = max(0, math.ceil(intersections[index]))
+                right = min(self.width - 1, math.floor(intersections[index + 1]))
+                if left <= right:
+                    row = fill_rgb * (right - left + 1)
+                    offset = (y * self.width + left) * 3
+                    self.pixels[offset:offset + len(row)] = row
+        for first, second in zip(closed, closed[1:]):
+            self.line(first, second, outline, width)
+
+    def text(
+        self,
+        position: tuple[int, int],
+        value: str,
+        *,
+        fill: str,
+        scale: int,
+        bold: bool = False,
+    ) -> None:
+        x, y = position
+        colour = _rgb(fill)
+        advance = 6 * scale
+        for character in value.upper():
+            rows = _FONT_5X7.get(character, _FONT_5X7["?"])
+            for row_index, bits in enumerate(rows):
+                for column in range(5):
+                    if bits & (1 << (4 - column)):
+                        left = x + column * scale
+                        top = y + row_index * scale
+                        for py in range(top, top + scale):
+                            for px in range(left, left + scale + (1 if bold else 0)):
+                                self._set(px, py, colour)
+            x += advance
+
+    def png(self) -> bytes:
+        stride = self.width * 3
+        raw = bytearray()
+        for y in range(self.height):
+            raw.append(0)
+            start = y * stride
+            raw.extend(self.pixels[start:start + stride])
+
+        def chunk(name: bytes, data: bytes) -> bytes:
+            checksum = binascii.crc32(name)
+            checksum = binascii.crc32(data, checksum) & 0xFFFFFFFF
+            return struct.pack(">I", len(data)) + name + data + struct.pack(">I", checksum)
+
+        header = struct.pack(">IIBBBBB", self.width, self.height, 8, 2, 0, 0, 0)
+        return (
+            PNG_SIGNATURE
+            + chunk(b"IHDR", header)
+            + chunk(b"IDAT", zlib.compress(bytes(raw), level=9))
+            + chunk(b"IEND", b"")
+        )
+
+
+def _stdlib_text_width(value: str, scale: int) -> int:
+    return max(0, len(value) * 6 * scale - scale)
+
+
+def _stdlib_trim(value: str, maximum_width: int, scale: int) -> str:
+    maximum_chars = max(1, (maximum_width + scale) // (6 * scale))
+    if len(value) <= maximum_chars:
+        return value
+    if maximum_chars <= 3:
+        return value[:maximum_chars]
+    return value[:maximum_chars - 3] + "..."
+
+
+def _draw_stdlib_panel(
+    raster: _StdlibRaster,
+    frame: tuple[int, int, int, int],
+    view: tuple[float, float, float, float],
+    visible: list[dict[str, Any]],
+    changed: Mapping[str, Mapping[str, str]],
+    colours: Mapping[str, str],
+    *,
+    proposed: bool,
+) -> None:
+    background = "#F7F9FB"
+    frame_width = frame[2] - frame[0]
+    frame_height = frame[3] - frame[1]
+    panel = _StdlibRaster(frame_width, frame_height, background)
+    local_frame = (0, 0, frame_width - 1, frame_height - 1)
+    changed_width = 3 if len(changed) <= 50 else 2 if len(changed) <= 250 else 1
+    for cell in visible:
+        dguid = cell["dguid"]
+        tag = changed[dguid]["to"] if proposed and dguid in changed else cell["leaf"]
+        fill = _lighten(colours[tag]) if tag in colours else "#E7EBEF"
+        outline = "#151B23" if dguid in changed else "#AEB7C0"
+        width = changed_width if dguid in changed else 1
+        for polygon in cell["polygons"]:
+            outer = _screen_ring(polygon[0], view, local_frame)
+            panel.polygon(outer, fill=fill, outline=outline, width=width)
+            for hole in polygon[1:]:
+                interior = _screen_ring(hole, view, local_frame)
+                panel.polygon(interior, fill=background, outline=outline, width=1)
+    raster.paste(panel, (frame[0], frame[1]))
+    raster.rectangle(frame, outline="#B7C0C9", width=2)
+
+
+def _render_stdlib_preview(
+    *,
+    changed: Mapping[str, Mapping[str, str]],
+    visible: list[dict[str, Any]],
+    colours: Mapping[str, str],
+    involved_tags: list[str],
+    pruid: str,
+    view: tuple[float, float, float, float],
+) -> bytes:
+    raster = _StdlibRaster(IMAGE_WIDTH, IMAGE_HEIGHT, "#FFFFFF")
+    raster.text((52, 34), "PROPOSED BOUNDARY CHANGE", fill="#111827", scale=6, bold=True)
+
+    pill_text = "PREVIEW - NOT APPROVED"
+    pill_scale = 3
+    pill_width = _stdlib_text_width(pill_text, pill_scale) + 34
+    pill_left = IMAGE_WIDTH - pill_width - 52
+    raster.rectangle((pill_left, 38, IMAGE_WIDTH - 52, 82), fill="#FFF0E8", outline="#D55E00", width=2)
+    raster.text((pill_left + 17, 49), pill_text, fill="#8C2D04", scale=pill_scale, bold=True)
+
+    province = PROVINCE_NAMES.get(pruid, f"Jurisdiction {pruid}")
+    count = len(changed)
+    subtitle = f"{count:,} CENSUS CELL{'S' if count != 1 else ''} | {province}"
+    raster.text((54, 99), _stdlib_trim(subtitle, 1490, 4), fill="#4B5563", scale=4)
+
+    move_counts = Counter((change["from"], change["to"]) for change in changed.values())
+    summary_parts = [
+        f"{_tag_label(source, 18)} > {_tag_label(target, 18)}: {move_count:,}"
+        for (source, target), move_count in sorted(move_counts.items())[:3]
+    ]
+    if len(move_counts) > 3:
+        summary_parts.append(f"+{len(move_counts) - 3} MORE")
+    move_summary = " | ".join(summary_parts)
+    raster.text((54, 145), _stdlib_trim(move_summary, 1490, 3), fill="#374151", scale=3)
+
+    current_frame = (42, 222, 766, 887)
+    proposed_frame = (834, 222, 1558, 887)
+    raster.text((48, 184), "CURRENT", fill="#4B5563", scale=4, bold=True)
+    raster.text((840, 184), "PROPOSED", fill="#111827", scale=4, bold=True)
+    _draw_stdlib_panel(raster, current_frame, view, visible, changed, colours, proposed=False)
+    _draw_stdlib_panel(raster, proposed_frame, view, visible, changed, colours, proposed=True)
+
+    legend_x = 54
+    legend_y = 916
+    for index, tag in enumerate(involved_tags[:8]):
+        x = legend_x + index * 132
+        raster.rectangle(
+            (x, legend_y, x + 24, legend_y + 24),
+            fill=_lighten(colours[tag]),
+            outline=colours[tag],
+            width=2,
+        )
+        raster.text((x + 32, legend_y + 2), _tag_label(tag, 10), fill="#29313A", scale=3)
+    if len(involved_tags) > 8:
+        raster.text(
+            (legend_x + 8 * 132, legend_y + 2),
+            f"+{len(involved_tags) - 8} REGIONS",
+            fill="#4B5563",
+            scale=3,
+        )
+
+    footer = "OUTLINED CELLS WOULD MOVE. GENERATED FROM CURRENT MESHCORE CANADA REGION DATA."
+    raster.text((54, 959), _stdlib_trim(footer, 1490, 3), fill="#5F6B76", scale=3)
+    payload = raster.png()
+    if not payload.startswith(PNG_SIGNATURE):
+        raise PreviewRenderError("the boundary preview encoder failed")
+    return payload
 
 
 def _font(size: int, *, bold: bool = False) -> ImageFont.ImageFont:
@@ -391,6 +739,16 @@ def render_boundary_preview(canonical: Mapping[str, Any], topology: object) -> b
         tag: REGION_PALETTE[index % len(REGION_PALETTE)]
         for index, tag in enumerate(involved_tags)
     }
+
+    if Image is None:
+        return _render_stdlib_preview(
+            changed=changed,
+            visible=visible,
+            colours=colours,
+            involved_tags=involved_tags,
+            pruid=pruid,
+            view=view,
+        )
 
     image = Image.new("RGB", (IMAGE_WIDTH, IMAGE_HEIGHT), "#FFFFFF")
     draw = ImageDraw.Draw(image)

--- a/tools/region-proposal-gateway/tests/test_gateway.py
+++ b/tools/region-proposal-gateway/tests/test_gateway.py
@@ -6,6 +6,7 @@ import io
 import json
 import os
 import stat
+import subprocess
 import sys
 import tempfile
 import threading
@@ -16,6 +17,7 @@ from unittest import mock
 from PIL import Image
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import boundary_preview  # noqa: E402
 import gateway  # noqa: E402
 
 
@@ -190,6 +192,23 @@ class ProposalValidationTests(unittest.TestCase):
 
 
 class PreviewTests(unittest.TestCase):
+    def test_gateway_imports_without_site_packages(self):
+        gateway_dir = str(Path(__file__).resolve().parents[1])
+        code = (
+            "import sys;"
+            f"sys.path.insert(0, {gateway_dir!r});"
+            "import boundary_preview, gateway;"
+            "assert boundary_preview.Image is None"
+        )
+        completed = subprocess.run(
+            [sys.executable, "-S", "-c", code],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
     def test_renders_deterministic_current_and_proposed_png(self):
         with tempfile.TemporaryDirectory() as temporary:
             paths = write_authority(Path(temporary))
@@ -201,6 +220,25 @@ class PreviewTests(unittest.TestCase):
             topology = authority.topology(snapshot, "35")
             first = gateway.render_boundary_preview(canonical, topology)
             second = gateway.render_boundary_preview(canonical, topology)
+            self.assertEqual(first, second)
+            self.assertLess(len(first), gateway.MAX_PREVIEW_BYTES)
+            with Image.open(io.BytesIO(first)) as image:
+                self.assertEqual(image.format, "PNG")
+                self.assertEqual(image.size, (1600, 1000))
+                self.assertEqual(image.mode, "RGB")
+
+    def test_renders_valid_preview_without_pillow_at_runtime(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            paths = write_authority(Path(temporary))
+            authority = gateway.AuthorityCache(*paths[:3])
+            snapshot = authority.get()
+            canonical, _, _ = gateway.validate_proposal(
+                valid_proposal(snapshot.membership_sha256), snapshot
+            )
+            topology = authority.topology(snapshot, "35")
+            with mock.patch.object(boundary_preview, "Image", None):
+                first = gateway.render_boundary_preview(canonical, topology)
+                second = gateway.render_boundary_preview(canonical, topology)
             self.assertEqual(first, second)
             self.assertLess(len(first), gateway.MAX_PREVIEW_BYTES)
             with Image.open(io.BytesIO(first)) as image:


### PR DESCRIPTION
## Summary
- keep the submission gateway importable when the host Python does not have Pillow
- render the same deterministic 1600x1000 Current/Proposed boundary PNG with a standard-library fallback
- retain Pillow as the preferred container renderer
- add regression coverage for `python -S` startup and fallback PNG output

## Production failure fixed
The live API returned 502 because `gateway.py` imported `PIL` at process startup and the production Python environment did not contain that package. This change prevents an optional renderer dependency from taking down both boundary and community submissions.

## Validation
- gateway: 44 passed, 1 expected Windows permissions skip
- approval automation: 14 passed
- editor/browser contracts: 47 passed
- region validation: 193 leaves, zero positive-area overlaps
- display and digital geometry verification: passed
- strict MkDocs build: passed
- production routing/secret scan: clean
- real Ontario fallback preview: 1600x1000 PNG, 24 KB, ~1.3 seconds