### PR TITLE
Auto-run region config lookup from q query

### DIFF
--- a/docs/assets/regions/regions.js
+++ b/docs/assets/regions/regions.js
@@ -1702,6 +1702,11 @@
         renderResult(data, els.result, state);
       });
     });
+    var initialQuery = new URLSearchParams(window.location.search).get("q");
+    if (initialQuery) {
+      els.input.value = initialQuery.trim();
+      setTimeout(locate, 0);
+    }
     showStep(1);
   }
 


### PR DESCRIPTION
This PR auto-runs the config location lookup when ?q= is present on /config/, so a pasted city/code from homepage search immediately resolves without requiring manual 'Find'.

Also deployed to pi test route 192.168.0.24:9000/meshcore-canada/.