### PR TITLE
Add Alberta communities and update StoonMesh

### DIFF
--- a/docs/provinces/alberta.md
+++ b/docs/provinces/alberta.md
@@ -6,6 +6,36 @@ If you know of a community that is missing or needs an update, open an update re
 
 ## Communities
 
+### Alberta MeshCore Networks (AlbertaMesh.ca)
+
+| Field | Value |
+|-------|-------|
+| Region | Alberta |
+| Status | Active |
+| Description | Building Alberta's community-operated off-grid LoRa mesh network |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Website | [AlbertaMesh.ca](https://albertamesh.ca/) |
+| Discord | <https://discord.gg/CznDhsRWnJ> |
+| Regional pages | [Airdrie](https://albertamesh.ca/airdrie/) · [Calgary](https://albertamesh.ca/calgary/) · [Edmonton](https://albertamesh.ca/edmonton/) · [Lethbridge](https://albertamesh.ca/lethbridge/) |
+| Resources | [Why MeshCore?](https://albertamesh.ca/why-meshcore/) · [Monitoring tools](https://albertamesh.ca/monitoring-tools/) |
+
+### Airdrie MeshCore Network
+
+| Field | Value |
+|-------|-------|
+| Region | Airdrie and Calgary |
+| Status | Active |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Regional identifier | `YYC` (shared with the Calgary regional network) |
+| Website | [Airdrie MeshCore Network](https://albertamesh.ca/airdrie/) |
+| Configuration | [Airdrie configuration guide](https://albertamesh.ca/airdrie/configuration/) |
+| Discord | <https://discord.gg/CznDhsRWnJ> |
+| Maps | [MeshMapper](https://yyc.meshmapper.net/?lat=51.28120&lon=-113.99718&zoom=13.43) · [WAeV](https://waev.app/#/live-map/@51.28107,-113.99966,14.47z) |
+
 ### Calgary and Area MeshCore
 
 | Field | Value |
@@ -18,6 +48,52 @@ If you know of a community that is missing or needs an update, open an update re
 | Telegram | Calgary topic in [Mesh Alberta](https://t.me/meshtAlta) |
 | Discord | Canada - Calgary, Alberta & Area regional channel in the MeshCore Discord |
 
+### Calgary MeshCore Network
+
+| Field | Value |
+|-------|-------|
+| Region | Calgary |
+| Status | Active |
+| Network role | Initial AlbertaMesh.ca launch region |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Website | [Calgary MeshCore Network](https://meshcorecalgary.ca/) |
+| Community guide | [Calgary on AlbertaMesh.ca](https://albertamesh.ca/calgary/) |
+| Discord | <https://discord.gg/CznDhsRWnJ> |
+| Maps and monitoring | [MeshMapper](https://yyc.meshmapper.net/?lat=51.01674&lon=-114.00149&zoom=11.00) · [CoreScope YYC](https://corescopeyyc.meshmonitoring.com/#/live) |
+| RX channels | [Recommended Calgary channels](https://albertamesh.ca/calgary/#rx-channels) |
+
+### Edmonton MeshCore Network
+
+| Field | Value |
+|-------|-------|
+| Region | Edmonton |
+| Status | Active |
+| Network role | Edmonton regional community within Alberta MeshCore |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Website | [Edmonton on AlbertaMesh.ca](https://albertamesh.ca/edmonton/) |
+| Configuration | [Edmonton configuration guide](https://albertamesh.ca/edmonton/configuration/) |
+| Discord | <https://discord.gg/CznDhsRWnJ> |
+| MeshMapper | [Edmonton network map](https://yeg.meshmapper.net/?lat=53.45752&lon=-113.58320&zoom=10.03) |
+
+### yegmesh.ca
+
+| Field | Value |
+|-------|-------|
+| Region | Edmonton |
+| Status | Active |
+| Description | Edmonton mesh network community focused on MeshCore |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |
+| Website | [Getting started](https://yegmesh.ca/p/getting-started) |
+| Local defaults | [MeshCore defaults](https://yegmesh.ca/p/meshcore-defaults) |
+| Discord | <https://discord.gg/CznDhsRWnJ> |
+| MeshMapper | [Edmonton network map](https://yeg.meshmapper.net/?lat=53.45752&lon=-113.58320&zoom=10.03) |
+
 ### YQLMesh
 
 | Field | Value |
@@ -27,9 +103,12 @@ If you know of a community that is missing or needs an update, open an update re
 | Radio preset | `USA/Canada (Recommended)` |
 | Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
 | Path hash mode | `3-byte` |
-| Website | <https://www.yqlmesh.com> |
-| Facebook | [YQLMesh Community](https://www.facebook.com/groups/839542635605360) |
-| Discord | <https://discord.gg/89DUBvmvu2> |
+| Description | Connecting Lethbridge, one node at a time |
+| Website | <https://www.yqlmesh.com/> |
+| AlbertaMesh guide | [Lethbridge regional page](https://albertamesh.ca/lethbridge/) |
+| Discord | <https://discord.gg/cFY9GSR37W> |
+| MeshMapper | [Lethbridge network map](https://yql.meshmapper.net/?lat=49.69091&lon=-112.86356&zoom=12.14) |
+| Social | [Facebook](https://facebook.com/groups/YQLMesh) · [Instagram](https://instagram.com/YQLMesh) · [X](https://x.com/YQLMesh) · [Reddit](https://www.reddit.com/r/YQLMesh) |
 
 ### Southern Alberta
 

--- a/docs/provinces/saskatchewan.md
+++ b/docs/provinces/saskatchewan.md
@@ -14,5 +14,5 @@ If you know of a community that is missing or needs an update, open an update re
 | Status | Active |
 | Radio preset | `USA/Canada (Recommended)` |
 | Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
-| Path hash mode | `1-byte` |
+| Path hash mode | `3-byte` |
 | Discord | <https://discord.gg/7yGnJuMGkG> |


### PR DESCRIPTION
## Summary

- add Alberta MeshCore Networks plus the submitted Airdrie, Calgary, Edmonton, and yegmesh.ca directory entries
- refresh the existing YQLMesh listing with the newly submitted website, regional, Discord, map, and social links
- update StoonMesh from 1-byte to the requested national-standard 3-byte path hash mode
- use the established USA/Canada national radio baseline where the new-community forms left radio fields blank

## Why

These directory changes implement the actionable community submissions in issues #67–#74. They make the Alberta listings easier to discover while keeping the existing scan-friendly province table format.

Issue #71 is a closed, unrelated pull request ("Auto-run region config lookup from q query"), not a community submission, so it has no directory change in this PR.

## Validation

- `python scripts/validate_community_submission.py`
- `mkdocs build --strict --site-dir C:\tmp\mcc-communities-67-74-site-019f890d`
- rendered HTML checks for all new headings, the updated YQLMesh Discord link, and StoonMesh's 3-byte value
- `git diff --check`

Closes #67
Closes #68
Closes #69
Closes #70
Closes #72
Closes #73
Closes #74