### PR TITLE
Add YQRMesh (Regina) to Saskatchewan

### DIFF
--- a/docs/provinces/saskatchewan.md
+++ b/docs/provinces/saskatchewan.md
@@ -16,3 +16,14 @@ If you know of a community that is missing or needs an update, open an update re
 | Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
 | Path hash mode | `1-byte` |
 | Discord | <https://discord.gg/7yGnJuMGkG> |
+
+
+### YQRMesh
+
+  | Field | Value |
+  |-------|-------|
+  | Region | Regina / Southern Saskatchewan |
+  | Status | Forming |
+  | Radio preset | `USA/Canada (Recommended)` |
+  | Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+  | Path hash mode | `3-byte` |

--- a/docs/provinces/saskatchewan.md
+++ b/docs/provinces/saskatchewan.md
@@ -20,10 +20,10 @@ If you know of a community that is missing or needs an update, open an update re
 
 ### YQRMesh
 
-  | Field | Value |
-  |-------|-------|
-  | Region | Regina / Southern Saskatchewan |
-  | Status | Forming |
-  | Radio preset | `USA/Canada (Recommended)` |
-  | Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
-  | Path hash mode | `3-byte` |
+| Field | Value |
+|-------|-------|
+| Region | Regina / Southern Saskatchewan |
+| Status | Forming |
+| Radio preset | `USA/Canada (Recommended)` |
+| Raw radio values | `910.525 MHz / 62.5 kHz / SF7 / CR5` |
+| Path hash mode | `3-byte` |


### PR DESCRIPTION
Adding YQRMesh, a new forming community for Regina / Southern Saskatchewan, using the same provincial radio settings as StoonMesh for future interoperability.
